### PR TITLE
Add statement delete & unreconcile support

### DIFF
--- a/app/src/dataAccess.ts
+++ b/app/src/dataAccess.ts
@@ -737,6 +737,36 @@ export class DataAccess {
     if (!response.ok) throw new Error(`Failed to save statement: ${response.statusText}`);
   }
 
+  async deleteStatement(
+    familyId: string,
+    accountNumber: string,
+    statementId: string,
+    transactionRefs: { budgetId: string; transactionId: string }[]
+  ): Promise<void> {
+    const headers = await this.getAuthHeaders();
+    const response = await fetch(`${this.apiBaseUrl}/families/${familyId}/accounts/${accountNumber}/statements/${statementId}`, {
+      method: "DELETE",
+      headers,
+      body: JSON.stringify({ transactions: transactionRefs }),
+    });
+    if (!response.ok) throw new Error(`Failed to delete statement: ${response.statusText}`);
+  }
+
+  async unreconcileStatement(
+    familyId: string,
+    accountNumber: string,
+    statementId: string,
+    transactionRefs: { budgetId: string; transactionId: string }[]
+  ): Promise<void> {
+    const headers = await this.getAuthHeaders();
+    const response = await fetch(`${this.apiBaseUrl}/families/${familyId}/accounts/${accountNumber}/statements/${statementId}/unreconcile`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ transactions: transactionRefs }),
+    });
+    if (!response.ok) throw new Error(`Failed to unreconcile statement: ${response.statusText}`);
+  }
+
   // Entity Functions
   async createEntity(familyId: string, entity: Entity): Promise<{ entityId: string }> {
     const headers = await this.getAuthHeaders();

--- a/app/src/store/statements.ts
+++ b/app/src/store/statements.ts
@@ -26,5 +26,25 @@ export const useStatementStore = defineStore("statements", () => {
     await loadStatements(familyId, accountNumber);
   }
 
-  return { statements, loadStatements, getStatements, saveStatement };
+  async function deleteStatement(
+    familyId: string,
+    accountNumber: string,
+    statementId: string,
+    transactionRefs: { budgetId: string; transactionId: string }[]
+  ) {
+    await dataAccess.deleteStatement(familyId, accountNumber, statementId, transactionRefs);
+    await loadStatements(familyId, accountNumber);
+  }
+
+  async function unreconcileStatement(
+    familyId: string,
+    accountNumber: string,
+    statementId: string,
+    transactionRefs: { budgetId: string; transactionId: string }[]
+  ) {
+    await dataAccess.unreconcileStatement(familyId, accountNumber, statementId, transactionRefs);
+    await loadStatements(familyId, accountNumber);
+  }
+
+  return { statements, loadStatements, getStatements, saveStatement, deleteStatement, unreconcileStatement };
 });


### PR DESCRIPTION
## Summary
- add delete and unreconcile endpoints for statements on server
- update service logic to revert transaction statuses
- expose delete/unreconcile APIs in client dataAccess and store
- update TransactionRegistry UI to allow deleting and unreconciling statements

## Testing
- `dotnet build` *(fails: command not found)*
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_b_684588389b448329b9283940a84bf706