### PR TITLE
Fix TypeScript config and imports

### DIFF
--- a/quasar/src/store/entities.ts
+++ b/quasar/src/store/entities.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 import { Family, Entity } from "../types";
 import { dataAccess } from "../dataAccess";
-import { auth } from "@/firebase";
+import { auth } from "@/firebase/index";
 
 export const useFamilyStore = defineStore("family", () => {
   const family = ref<Family>();

--- a/quasar/src/store/family.ts
+++ b/quasar/src/store/family.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 import { Family, Entity, EntityType } from "../types";
 import { dataAccess } from "../dataAccess";
-import { auth } from "@/firebase";
+import { auth } from "@/firebase/index";
 
 export const useFamilyStore = defineStore("family", () => {
   const family = ref<Family>();

--- a/quasar/src/store/index.ts
+++ b/quasar/src/store/index.ts
@@ -1,9 +1,0 @@
-import { createStore } from "vuex";
-
-export default createStore({
-  state: {},
-  getters: {},
-  mutations: {},
-  actions: {},
-  modules: {},
-});

--- a/quasar/src/types.ts
+++ b/quasar/src/types.ts
@@ -35,6 +35,12 @@ export interface Transaction {
   id: string;
   date: string;
   budgetMonth?: string;
+  /**
+   * Optional budget identifier. Some views expect transactions
+   * to reference the budget they belong to when returned from
+   * the backend, so include this field for convenience.
+   */
+  budgetId?: string;
   merchant: string;
   categories: Array<{
     category: string;

--- a/quasar/tsconfig.json
+++ b/quasar/tsconfig.json
@@ -1,3 +1,19 @@
 {
-  "extends": "./.quasar/tsconfig.json"
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "lib": ["esnext", "dom", "dom.iterable", "scripthost"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "quasar.config.ts"]
 }


### PR DESCRIPTION
## Summary
- setup a full tsconfig to allow local typechecking
- remove unused vuex store stub
- update firebase imports in stores
- add optional `budgetId` to Transaction type

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_684611bb5920832988126089619510a4