### PR TITLE
Fix lint warnings

### DIFF
--- a/quasar/src/store/auth.ts
+++ b/quasar/src/store/auth.ts
@@ -2,7 +2,7 @@
 import { defineStore } from "pinia";
 import { auth } from "../firebase";
 import { ref } from "vue";
-import { User } from "firebase/auth";
+import type { User } from "firebase/auth";
 
 export const useAuthStore = defineStore("auth", () => {
   let user: User | null = null;
@@ -25,3 +25,4 @@ export const useAuthStore = defineStore("auth", () => {
 
   return { user, avatarSrc, initializeAuth, signOut };
 });
+

--- a/quasar/src/store/budget.ts
+++ b/quasar/src/store/budget.ts
@@ -1,7 +1,7 @@
 /** budget.ts */
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
-import { Budget } from "../types";
+import type { Budget } from "../types";
 import { dataAccess } from "../dataAccess";
 
 export const useBudgetStore = defineStore("budgets", () => {
@@ -19,7 +19,7 @@ export const useBudgetStore = defineStore("budgets", () => {
         }
       }
       budgets.value = newBudgets;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error loading budgets:", error);
     }
   }
@@ -58,3 +58,4 @@ export const useBudgetStore = defineStore("budgets", () => {
     availableBudgetMonths,
   };
 });
+

--- a/quasar/src/store/entities.ts
+++ b/quasar/src/store/entities.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import { Family, Entity } from "../types";
+import type { Family, Entity } from "../types";
+import { EntityType } from "../types";
 import { dataAccess } from "../dataAccess";
 import { auth } from "@/firebase/index";
 
@@ -15,12 +16,13 @@ export const useFamilyStore = defineStore("family", () => {
       if (f) {
         family.value = f;
         if (f.entities?.length) {
-          const defaultEntity = f.entities.find(e => e.type === "Family") || f.entities[0];
+          const defaultEntity =
+            f.entities.find((e) => e.type === EntityType.Family) || f.entities[0];
           selectedEntityId.value = defaultEntity.id;
         }
         return f;
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error loading Family", error);
     }
     return null;
@@ -32,7 +34,7 @@ export const useFamilyStore = defineStore("family", () => {
         await loadFamily();
       }
       return family.value;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error getting Family", error);
     }
     return null;
@@ -49,7 +51,7 @@ export const useFamilyStore = defineStore("family", () => {
         }
       }
       return response.entityId;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error creating entity", error);
       throw error;
     }
@@ -63,7 +65,7 @@ export const useFamilyStore = defineStore("family", () => {
           e.id === entity.id ? entity : e
         ) || [];
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error updating entity", error);
       throw error;
     }
@@ -78,7 +80,7 @@ export const useFamilyStore = defineStore("family", () => {
           selectedEntityId.value = family.value.entities[0]?.id || "";
         }
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error deleting entity", error);
       throw error;
     }
@@ -96,7 +98,7 @@ export const useFamilyStore = defineStore("family", () => {
           }
         }
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error adding entity member", error);
       throw error;
     }
@@ -111,7 +113,7 @@ export const useFamilyStore = defineStore("family", () => {
           entity.members = entity.members?.filter(m => m.uid !== memberUid) || [];
         }
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error removing entity member", error);
       throw error;
     }
@@ -134,3 +136,4 @@ export const useFamilyStore = defineStore("family", () => {
     selectEntity,
   };
 });
+

--- a/quasar/src/store/family.ts
+++ b/quasar/src/store/family.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import { Family, Entity, EntityType } from "../types";
+import type { Family, Entity } from "../types";
+import { EntityType } from "../types";
 import { dataAccess } from "../dataAccess";
 import { auth } from "@/firebase/index";
 
@@ -21,7 +22,7 @@ export const useFamilyStore = defineStore("family", () => {
         }
         return f;
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error loading Family", error);
     }
     return null;
@@ -33,7 +34,7 @@ export const useFamilyStore = defineStore("family", () => {
         await loadFamily();
       }
       return family.value;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error getting Family", error);
     }
     return null;
@@ -50,7 +51,7 @@ export const useFamilyStore = defineStore("family", () => {
         }
       }
       return response.entityId;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error creating entity", error);
       throw error;
     }
@@ -64,7 +65,7 @@ export const useFamilyStore = defineStore("family", () => {
           e.id === entity.id ? entity : e
         ) || [];
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error updating entity", error);
       throw error;
     }
@@ -79,7 +80,7 @@ export const useFamilyStore = defineStore("family", () => {
           selectedEntityId.value = family.value.entities[0]?.id || "";
         }
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error deleting entity", error);
       throw error;
     }
@@ -97,7 +98,7 @@ export const useFamilyStore = defineStore("family", () => {
           }
         }
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error adding entity member", error);
       throw error;
     }
@@ -112,7 +113,7 @@ export const useFamilyStore = defineStore("family", () => {
           entity.members = entity.members?.filter(m => m.uid !== memberUid) || [];
         }
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Error removing entity member", error);
       throw error;
     }
@@ -135,3 +136,4 @@ export const useFamilyStore = defineStore("family", () => {
     selectEntity,
   };
 });
+

--- a/quasar/src/store/merchants.ts
+++ b/quasar/src/store/merchants.ts
@@ -1,5 +1,5 @@
 // src/store/merchants.ts
-import { Transaction } from "@/types";
+import type { Transaction } from "@/types";
 import { defineStore } from "pinia";
 import { ref, computed } from "vue";
 
@@ -53,3 +53,4 @@ export const useMerchantStore = defineStore("merchants", () => {
     merchantNames,
   };
 });
+

--- a/quasar/src/store/plugins/persistedState.ts
+++ b/quasar/src/store/plugins/persistedState.ts
@@ -1,6 +1,6 @@
-import { PiniaPluginContext } from 'pinia';
+import type { PiniaPluginContext } from 'pinia';
 
-function replacer(_key: string, value: any) {
+function replacer(_key: string, value: unknown) {
   if (value instanceof Map) {
     return {
       __type: 'Map',
@@ -10,9 +10,13 @@ function replacer(_key: string, value: any) {
   return value;
 }
 
-function reviver(_key: string, value: any) {
-  if (value && value.__type === 'Map') {
-    return new Map(value.value);
+function reviver(_key: string, value: unknown) {
+  if (
+    value &&
+    typeof value === 'object' &&
+    (value as { __type?: string }).__type === 'Map'
+  ) {
+    return new Map((value as { value: [unknown, unknown][] }).value);
   }
   return value;
 }

--- a/quasar/src/store/statements.ts
+++ b/quasar/src/store/statements.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import { Statement } from "@/types";
+import type { Statement } from "@/types";
 import { dataAccess } from "@/dataAccess";
 
 export const useStatementStore = defineStore("statements", () => {
@@ -48,3 +48,4 @@ export const useStatementStore = defineStore("statements", () => {
 
   return { statements, loadStatements, getStatements, saveStatement, deleteStatement, unreconcileStatement };
 });
+

--- a/quasar/src/types.ts
+++ b/quasar/src/types.ts
@@ -1,5 +1,5 @@
 /** types.ts */
-import { Timestamp } from "firebase/firestore";
+import type { Timestamp } from "firebase/firestore";
 
 export interface Family {
   id: string;
@@ -250,3 +250,4 @@ export interface Statement {
   endingBalance: number;
   reconciled: boolean;
 }
+

--- a/quasar/src/utils/helpers.ts
+++ b/quasar/src/utils/helpers.ts
@@ -1,6 +1,7 @@
 // src/utils/helpers.ts
 
-import { EntityType, Transaction } from "@/types";
+import { EntityType } from "@/types";
+import type { Transaction } from "@/types";
 import { v4 as uuidv4 } from "uuid";
 import { Timestamp } from "firebase/firestore";
 
@@ -29,12 +30,17 @@ export function formatDate(date: string | Date): string {
 }
 
 // Format a Timestamp to a readable string
-export function formatTimestamp(timestamp: any) {
-  if (!timestamp || typeof timestamp !== "object" || !timestamp.seconds) {
+export function formatTimestamp(timestamp: unknown) {
+  if (
+    !timestamp ||
+    typeof timestamp !== "object" ||
+    !(timestamp as { seconds?: unknown }).seconds
+  ) {
     return "Invalid timestamp";
   }
 
-  const date = new Timestamp(timestamp.seconds, timestamp.nanoseconds).toDate();
+  const ts = timestamp as { seconds: number; nanoseconds: number };
+  const date = new Timestamp(ts.seconds, ts.nanoseconds).toDate();
   
   return date.toLocaleDateString("en-US", {
     month: "2-digit",
@@ -171,7 +177,7 @@ export function formatCurrency(amount: number | string): string {
  * @param value - Value to check
  * @returns Boolean indicating if the value is a valid number
  */
-export function isValidNumber(value: any): boolean {
+export function isValidNumber(value: unknown): boolean {
   return typeof value === "number" && !isNaN(value);
 }
 
@@ -358,3 +364,4 @@ export function formatEntityType(type: EntityType): string {
       return type;
   }
 }
+

--- a/quasar/src/version.ts
+++ b/quasar/src/version.ts
@@ -1,12 +1,4 @@
 // src/version.js
-let version = "0.0.0";
-try {
-  version =
-    process.env.VUE_APP_VERSION ||
-    require("../package.json").version ||
-    "0.0.0";
-} catch (error) {
-  console.error("Error loading package.json version:", error);
-  version = process.env.VUE_APP_VERSION || "0.0.0";
-}
+const version = process.env.VUE_APP_VERSION || "0.0.0";
 export default version;
+


### PR DESCRIPTION
## Summary
- fix lint issues with `import type`, typing for error handlers, map persistence
- remove forbidden require from version file
- update utility helpers to remove `any`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6846138746248329b9c909165023a1c8