### PR TITLE
Fix lint issue for AccountForm

### DIFF
--- a/quasar/src/components/AccountForm.vue
+++ b/quasar/src/components/AccountForm.vue
@@ -73,8 +73,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, defineProps, defineEmits } from "vue";
-import { Account, AccountType } from "../types";
+import { ref, watch, defineProps, defineEmits } from "vue";
+import type { Account } from "../types";
+import { AccountType } from "../types";
 import { Timestamp } from "firebase/firestore";
 
 const props = defineProps<{


### PR DESCRIPTION
## Summary
- fix unused `computed` import and use `import type` for Account

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68461d1ecd848329a29305ce3b00bf83