### PR TITLE
Fix Pinia initialization order

### DIFF
--- a/quasar/src/main.ts
+++ b/quasar/src/main.ts
@@ -42,6 +42,7 @@ app.use(Quasar, {
 });
 
 setupAuthListener();
-app.use(router);
+// Install Pinia before the router so navigation guards can access stores
 app.use(pinia);
+app.use(router);
 app.mount("#app");


### PR DESCRIPTION
## Summary
- ensure Pinia is installed before router so navigation guards can access stores

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68462cfe062483299121d92e01f78be8