### PR TITLE
Fix some TS errors

### DIFF
--- a/quasar/src/components/MatchBankTransactionsDialog.vue
+++ b/quasar/src/components/MatchBankTransactionsDialog.vue
@@ -811,7 +811,7 @@ async function matchBankTransaction(budgetTransaction: Transaction) {
         updatedTransaction.budgetMonth!,
         familyStore.family?.id || '',
         user.uid,
-        updatedTransaction.entityId,
+        updatedTransaction.entityId || '',
       );
     }
 
@@ -995,7 +995,7 @@ async function handleTransactionAdded(savedTransaction: Transaction) {
         savedTransaction.budgetMonth || "",
         family.id,
         user.uid,
-        savedTransaction.entityId,
+        savedTransaction.entityId || '',
       );
     }
 
@@ -1086,6 +1086,7 @@ async function addNewTransaction() {
     checkNumber: selectedBankTransaction.value.checkNumber,
     status: 'C',
     entityId: familyStore.selectedEntityId,
+    taxMetadata: [],
   };
   newTransactionBudgetId.value = `${props.userId}_${familyStore.selectedEntityId}_${budgetMonth}`;
   showTransactionDialog.value = true;

--- a/quasar/src/components/TransactionForm.vue
+++ b/quasar/src/components/TransactionForm.vue
@@ -370,10 +370,10 @@ onMounted(async () => {
   isInitialized.value = true;
 });
 
-function scrollToNoteField(event: FocusEvent) {
+function scrollToNoteField(evt: Event) {
   if (isMobile.value) {
     setTimeout(() => {
-      (event.target as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'center' });
+      (evt.target as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'center' });
     }, 300); // Delay to account for keyboard appearance
   }
 }

--- a/quasar/src/components/TransactionRegistry.vue
+++ b/quasar/src/components/TransactionRegistry.vue
@@ -564,6 +564,7 @@ import { useBudgetStore } from '../store/budget';
 import { useFamilyStore } from '../store/family';
 import { useStatementStore } from '../store/statements';
 import { useUIStore } from '../store/ui';
+import type { QForm } from 'quasar';
 import type {
   Transaction,
   ImportedTransaction,
@@ -631,17 +632,17 @@ const transactionAction = ref('');
 const showBalanceAdjustmentDialog = ref(false);
 const adjustmentAmount = ref<number>(0);
 const adjustmentDate = ref<string>(todayISO());
-const adjustmentForm = ref<QForm | null>(null); // Quasar doesn't have a specific QForm type
+const adjustmentForm = ref<InstanceType<typeof QForm> | null>(null); // Quasar doesn't have a specific QForm type
 const selectedRows = ref<string[]>([]);
 const showBatchMatchDialog = ref(false);
-const batchMatchForm = ref<QForm | null>(null);
+const batchMatchForm = ref<InstanceType<typeof QForm> | null>(null);
 const batchMerchant = ref('');
 const batchCategory = ref('');
 const selectedEntityId = ref<string>('');
 const showBatchActionDialog = ref(false);
 const batchAction = ref<string>('');
 const showStatementDialog = ref(false);
-const statementForm = ref<QForm | null>(null);
+const statementForm = ref<InstanceType<typeof QForm> | null>(null);
 const newStatement = ref<Statement>({
   id: '',
   accountNumber: '',
@@ -690,7 +691,7 @@ const latestTransactionBalance = computed(() => {
   if (selectedAccount.value && accounts.value) {
     const aInfo = accounts.value.filter((a) => (a.accountNumber ?? '') == selectedAccount.value);
     if (aInfo && aInfo.length > 0 && (aInfo[0].type == 'CreditCard' || aInfo[0].type == 'Loan')) {
-      return Math.abs(displayTransactions.value[0].balance) || 0;
+      return Math.abs(displayTransactions.value[0].balance || 0);
     }
   }
   return displayTransactions.value[0].balance || 0;
@@ -734,7 +735,7 @@ const displayTransactions = computed((): DisplayTransaction[] => {
       date: tx.date,
       merchant: tx.importedMerchant || tx.merchant || 'N/A',
       category: tx.categories && tx.categories.length > 0 ? tx.categories[0].category : 'N/A',
-      entityId: tx.entityId || budget.entityId,
+      entityId: tx.entityId || budget.entityId || '',
       amount: tx.isIncome || false ? tx.amount : -1 * tx.amount,
       isIncome: tx.isIncome || false,
       status: tx.status || 'C',
@@ -919,7 +920,7 @@ const statementTransactions = computed((): DisplayTransaction[] => {
       date: itx.postedDate,
       merchant: itx.payee || 'N/A',
       category: '',
-      entityId: itx.entityId || '',
+      entityId: '',
       amount: itx.debitAmount && itx.debitAmount > 0 ? -itx.debitAmount : itx.creditAmount || 0,
       isIncome: (itx.creditAmount || 0) > 0,
       status: itx.status || 'U',

--- a/quasar/src/pages/AccountsView.vue
+++ b/quasar/src/pages/AccountsView.vue
@@ -312,7 +312,7 @@ import { dataAccess } from '../dataAccess';
 import { useFamilyStore } from '../store/family';
 import AccountList from '../components/AccountList.vue';
 import AccountForm from '../components/AccountForm.vue';
-import { Account, Snapshot, ImportedTransaction, Transaction } from '../types';
+import { Account, Snapshot, ImportedTransaction, Transaction, AccountType } from '../types';
 import { formatCurrency, formatTimestamp, todayISO } from '../utils/helpers';
 import { v4 as uuidv4 } from 'uuid';
 import { Timestamp } from 'firebase/firestore';
@@ -334,7 +334,7 @@ const showDeleteAccountDialog = ref(false);
 const showDeleteSnapshotDialog = ref(false);
 const showBatchDeleteSnapshotDialog = ref(false);
 const showUpdateBudgetTransactionsDialog = ref(false);
-const accountType = ref<'Bank' | 'CreditCard' | 'Investment' | 'Property' | 'Loan'>('Bank');
+const accountType = ref<AccountType>(AccountType.Bank);
 const editMode = ref(false);
 const isPersonalAccount = ref(false);
 const selectAll = ref(false);
@@ -401,10 +401,10 @@ const loanAccounts = computed(() =>
 );
 
 const snapshotHeaders = ref([
-  { name: 'select', label: '', align: 'center', sortable: false },
+  { name: 'select', label: '', field: 'select', align: 'center', sortable: false },
   { name: 'date', label: 'Date', field: 'date', align: 'left', sortable: true },
   { name: 'netWorth', label: 'Net Worth', field: 'netWorth', align: 'left', sortable: true },
-  { name: 'actions', label: 'Actions', align: 'center', sortable: false },
+  { name: 'actions', label: 'Actions', field: 'actions', align: 'center', sortable: false },
 ]);
 
 const snapshotsWithSelection = computed(() => {

--- a/quasar/src/pages/DashboardView.vue
+++ b/quasar/src/pages/DashboardView.vue
@@ -161,7 +161,7 @@
                     <Currency-Input v-model.number="cat.target" label="Target" class="text-right" dense required />
                   </q-col>
                   <q-col cols="12" sm="2" class="q-pa-sm">
-                    <Currency-Input v-model="cat.carryover" label="Carryover" class="text-right" dense />
+                    <Currency-Input v-model.number="cat.carryover" label="Carryover" class="text-right" dense />
                   </q-col>
                   <q-col cols="12" sm="2" class="q-pa-sm">
                     <q-checkbox v-model="cat.isFund" label="Is Fund?" dense />


### PR DESCRIPTION
## Summary
- fix calls to `createBudgetForMonth` with string defaults
- include empty `taxMetadata` when creating new transactions
- tweak TransactionForm focus handler typing
- refine QForm types in TransactionRegistry
- fix computed balance default
- ensure DisplayTransaction entityId is always string
- fix QTable headers and AccountType typing in AccountsView
- use numeric v-model for category carryover

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_b_68462cdcab908329afe6bb0aefcc7136