### PR TITLE
Fix Quasar login layout

### DIFF
--- a/quasar/src/layouts/AuthLayout.vue
+++ b/quasar/src/layouts/AuthLayout.vue
@@ -1,0 +1,13 @@
+<template>
+  <q-layout view="lHh Lpr lFf">
+    <q-page-container>
+      <router-view />
+    </q-page-container>
+  </q-layout>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped>
+</style>

--- a/quasar/src/router/routes.ts
+++ b/quasar/src/router/routes.ts
@@ -16,7 +16,13 @@ const routes: RouteRecordRaw[] = [
       { path: 'accept-invite', component: () => import('pages/AcceptInvitePage.vue') },
     ],
   },
-  { path: '/login', component: () => import('pages/LoginPage.vue') },
+  {
+    path: '/login',
+    component: () => import('layouts/AuthLayout.vue'),
+    children: [
+      { path: '', component: () => import('pages/LoginPage.vue') },
+    ],
+  },
   { path: '/:catchAll(.*)*', component: () => import('pages/ErrorNotFound.vue') },
 ];
 


### PR DESCRIPTION
## Summary
- add simple `AuthLayout` using `q-layout`
- wrap login route in `AuthLayout` so `QPage` renders without error

## Testing
- `yarn lint` *(fails: quasar@workspace doesn't seem to be present in lockfile)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68465a4c3f30832992c5028b0d72ee2e