### PR TITLE
Fix env variable prefix for Vite

### DIFF
--- a/app/src/dataAccess.ts
+++ b/app/src/dataAccess.ts
@@ -18,7 +18,7 @@ import { useBudgetStore } from "./store/budget";
 import { Timestamp } from "firebase/firestore";
 
 export class DataAccess {
-  private apiBaseUrl = process.env.VUE_APP_API_BASE_URL || "http://localhost:8080/api";
+  private apiBaseUrl = import.meta.env.VITE_API_BASE_URL || "http://localhost:8080/api";
 
   private async getAuthHeaders(): Promise<HeadersInit> {
     const token = await auth.currentUser?.getIdToken();

--- a/app/src/firebase/auth.ts
+++ b/app/src/firebase/auth.ts
@@ -3,7 +3,7 @@ import { auth } from "./index";
 import { onAuthStateChanged, User } from "firebase/auth";
 
 
-const apiBaseUrl = process.env.VUE_APP_API_BASE_URL;
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
 export async function getIdToken(): Promise<string | null> {
   const user = auth.currentUser;

--- a/app/src/views/LoginView.vue
+++ b/app/src/views/LoginView.vue
@@ -34,7 +34,7 @@ const loading = ref(false);
 const error = ref("");
 const googleLoaded = ref(false);
 const router = useRouter();
-const apiBaseUrl = process.env.VUE_APP_API_BASE_URL;
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
 // Check if Google script is loaded and render button
 onMounted(() => {

--- a/app/src/views/VerifyEmail.vue
+++ b/app/src/views/VerifyEmail.vue
@@ -20,7 +20,7 @@ import { useRoute } from 'vue-router';
 const route = useRoute();
 const loading = ref(true);
 const error = ref('');
-const apiBaseUrl = process.env.VUE_APP_API_BASE_URL;
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
 onMounted(async () => {
   const token = route.query.token as string;

--- a/quasar/src/dataAccess.ts
+++ b/quasar/src/dataAccess.ts
@@ -18,7 +18,7 @@ import { useBudgetStore } from './store/budget';
 import { Timestamp } from 'firebase/firestore';
 
 export class DataAccess {
-  private apiBaseUrl = process.env.VUE_APP_API_BASE_URL || 'http://localhost:8080/api';
+  private apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api';
   private auth = useAuthStore();
 
   private async getAuthHeaders(): Promise<HeadersInit> {

--- a/quasar/src/pages/LoginPage.vue
+++ b/quasar/src/pages/LoginPage.vue
@@ -34,7 +34,7 @@ const error = ref("");
 const googleLoaded = ref(false);
 const router = useRouter();
 const auth = useAuthStore();
-const apiBaseUrl = process.env.VUE_APP_API_BASE_URL;
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
 // Check if Google script is loaded and render button
 onMounted(() => {

--- a/quasar/src/pages/VerifyEmailPage.vue
+++ b/quasar/src/pages/VerifyEmailPage.vue
@@ -20,7 +20,7 @@ import { useRoute } from 'vue-router';
 const route = useRoute();
 const loading = ref(true);
 const error = ref('');
-const apiBaseUrl = process.env.VUE_APP_API_BASE_URL;
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
 onMounted(async () => {
   const token = route.query.token as string;


### PR DESCRIPTION
## Summary
- use `import.meta.env.VITE_*` instead of `process.env.VUE_APP_*` so env vars load with Vite
- apply the fix across Quasar and Vue app sources

## Testing
- `npm test --prefix quasar`
- `npm test --prefix app` (fails: missing script)

------
https://chatgpt.com/codex/tasks/task_b_6846d4ba94108329b63f23c369dd75e8