### PR TITLE
Fix imports and button props for Quasar build

### DIFF
--- a/quasar/src/components/AccountList.vue
+++ b/quasar/src/components/AccountList.vue
@@ -29,7 +29,6 @@
         </template>
         <template v-slot:item.actions="{ item }">
           <q-btn
-            icon
             density="compact"
             variant="plain"
             color="primary"
@@ -39,7 +38,6 @@
             <q-icon>mdi-pencil</q-icon>
           </q-btn>
           <q-btn
-            icon
             density="compact"
             variant="plain"
             color="error"
@@ -59,7 +57,7 @@
 import { computed, defineProps, defineEmits } from "vue";
 import { Account, ImportedTransaction } from "../types";
 import { formatCurrency } from "../utils/helpers";
-import { auth } from "../firebase";
+import { auth } from "../firebase/init";
 
 const props = defineProps<{
   accounts: Account[];

--- a/quasar/src/components/EntityForm.vue
+++ b/quasar/src/components/EntityForm.vue
@@ -184,7 +184,7 @@ import { EntityType } from "../types";
 import CurrencyInput from "./CurrencyInput.vue";
 import { useBudgetStore } from "../store/budget";
 import { useFamilyStore } from "../store/family";
-import { auth } from "../firebase/index";
+import { auth } from "../firebase/init";
 import { DEFAULT_BUDGET_TEMPLATES } from "../constants/budgetTemplates";
 import { DEFAULT_TAX_FORMS } from "../constants/taxForms";
 import { v4 as uuidv4 } from "uuid";

--- a/quasar/src/components/MatchBankTransactionsDialog.vue
+++ b/quasar/src/components/MatchBankTransactionsDialog.vue
@@ -310,7 +310,7 @@ import { toDollars, toCents, toBudgetMonth, adjustTransactionDate, todayISO } fr
 import { dataAccess } from "../dataAccess";
 import { useBudgetStore } from "../store/budget";
 import { useFamilyStore } from "../store/family";
-import { auth } from "../firebase/index";
+import { auth } from "../firebase/init";
 import TransactionDialog from "./TransactionDialog.vue";
 import { VForm } from "vuetify/components";
 import { v4 as uuidv4 } from "uuid";

--- a/quasar/src/components/TransactionRegistry.vue
+++ b/quasar/src/components/TransactionRegistry.vue
@@ -498,7 +498,7 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from "vue";
 import { storeToRefs } from "pinia";
-import { auth } from "../firebase/index";
+import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
 import Papa from "papaparse";
 import { saveAs } from "file-saver";

--- a/quasar/src/pages/AcceptInvitePage.vue
+++ b/quasar/src/pages/AcceptInvitePage.vue
@@ -17,7 +17,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
 import { useRouter, useRoute } from "vue-router";
-import { auth } from "../firebase/index";
+import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
 
 const router = useRouter();

--- a/quasar/src/pages/AccountsPage.vue
+++ b/quasar/src/pages/AccountsPage.vue
@@ -221,7 +221,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue";
-import { auth } from "../firebase";
+import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
 import { useFamilyStore } from "../store/family";
 import AccountList from "../components/AccountList.vue";

--- a/quasar/src/pages/DataPage.vue
+++ b/quasar/src/pages/DataPage.vue
@@ -348,7 +348,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, computed } from "vue";
-import { auth } from "../firebase/index";
+import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
 import Papa from "papaparse";
 import { Budget, Transaction, Account, Entity, ImportedTransaction, ImportedTransactionDoc, Snapshot } from "../types";

--- a/quasar/src/pages/ReportsPage.vue
+++ b/quasar/src/pages/ReportsPage.vue
@@ -157,7 +157,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, computed } from "vue";
-import { auth } from "../firebase/index";
+import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
 import { Budget, Snapshot } from "../types";
 import { Doughnut, Line } from "vue-chartjs";

--- a/quasar/src/pages/SettingsPage.vue
+++ b/quasar/src/pages/SettingsPage.vue
@@ -210,7 +210,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed } from "vue";
-import { auth } from "../firebase/index";
+import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
 import { Timestamp } from "firebase/firestore";
 import { Family, PendingInvite, Entity, Budget, ImportedTransactionDoc } from "../types";

--- a/quasar/src/pages/SetupWizardPage.vue
+++ b/quasar/src/pages/SetupWizardPage.vue
@@ -148,7 +148,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch, nextTick } from "vue";
 import { useRouter } from "vue-router";
-import { auth } from "../firebase/index";
+import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
 import { useFamilyStore } from "../store/family";
 import EntityForm from "../components/EntityForm.vue";

--- a/quasar/src/pages/TransactionsPage.vue
+++ b/quasar/src/pages/TransactionsPage.vue
@@ -281,7 +281,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, watch } from "vue";
 import { storeToRefs } from "pinia";
-import { auth } from "../firebase";
+import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
 import TransactionDialog from "../components/TransactionDialog.vue";
 import MatchBankTransactionsDialog from "../components/MatchBankTransactionsDialog.vue";

--- a/quasar/src/store/entities.ts
+++ b/quasar/src/store/entities.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 import { Family, Entity } from "../types";
 import { dataAccess } from "../dataAccess";
-import { auth } from "../firebase";
+import { auth } from "../firebase/init";
 
 export const useFamilyStore = defineStore("family", () => {
   const family = ref<Family>();


### PR DESCRIPTION
## Summary
- clean up `AccountList` action buttons
- update firebase imports to use `init`

## Testing
- `npm run test`
- `npx vue-tsc --noEmit` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vue-tsc)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685271a01cfc83298c3f8a7a0d2fb8e2