### PR TITLE
Fix some vue-tsc warnings

### DIFF
--- a/quasar/src/components/MatchBudgetTransactionDialog.vue
+++ b/quasar/src/components/MatchBudgetTransactionDialog.vue
@@ -7,7 +7,7 @@
         <q-row>
           <q-col>
             <h3>Selected Budget Transaction</h3>
-            <q-table>
+            <q-markup-table>
               <thead>
                 <tr>
                   <th>Date</th>
@@ -26,7 +26,7 @@
                   </td>
                 </tr>
               </tbody>
-            </q-table>
+            </q-markup-table>
           </q-col>
         </q-row>
         <q-row class="mt-4">
@@ -192,7 +192,7 @@ function formatCategories(categories: { category: string; amount: number }[] | u
     return "No categories";
   }
   if (categories.length === 1) {
-    return categories[0].category;
+    return categories[0]?.category ?? "";
   }
   return categories.map((c) => `${c.category} ($${c.amount.toFixed(2)})`).join(",\n");
 }


### PR DESCRIPTION
## Summary
- switch static tables to q-markup-table
- tighten rule callbacks typing
- reference firebase init file
- remove Vuetify form import
- add missing taxMetadata fields and other TS assertions
- guard optional values in watchers and helpers
- fix category formatting in MatchBudgetTransactionDialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68527263ee608329b5f19b07010eb0db