### PR TITLE
Fix vue type issues

### DIFF
--- a/quasar/src/components/TransactionForm.vue
+++ b/quasar/src/components/TransactionForm.vue
@@ -183,7 +183,7 @@ import { Budget, Transaction } from "../types";
 import { toCents, toDollars, todayISO, currentMonthISO } from "../utils/helpers";
 import CurrencyInput from "./CurrencyInput.vue";
 import ToggleButton from "./ToggleButton.vue";
-import { VForm } from "vuetify/components";
+import { QForm } from "quasar";
 import { useMerchantStore } from "../store/merchants";
 import { useBudgetStore } from "../store/budget";
 
@@ -211,7 +211,7 @@ const snackbarColor = ref("success");
 
 const requiredField = [(value: string | null) => !!value || "This field is required", (value: string | null) => value !== "" || "This field is required"];
 
-const form = ref<InstanceType<typeof VForm> | null>(null);
+const form = ref<InstanceType<typeof QForm> | null>(null);
 
 const defaultTransaction: Transaction = {
   id: "",
@@ -285,7 +285,7 @@ onMounted(async () => {
     showSnackbar("No budgets available. Please create a budget in the Dashboard.", "warning");
   } else {
     if (!locTrnsx.budgetMonth || !availableMonths.value.includes(locTrnsx.budgetMonth)) {
-      locTrnsx.budgetMonth = availableMonths.value[0];
+      locTrnsx.budgetMonth = availableMonths.value[0] || "";
     }
   }
 
@@ -329,7 +329,7 @@ function removeSplit(index: number) {
     locTrnsx.categories.splice(index, 1);
   }
   if (locTrnsx.categories.length === 1) {
-    locTrnsx.categories[0].amount = locTrnsx.amount;
+    locTrnsx.categories[0]!.amount = locTrnsx.amount;
   }
 }
 
@@ -386,8 +386,8 @@ async function save() {
   if (valid) {
     loading.value = true;
     try {
-      if (locTrnsx.categories.length === 1 && locTrnsx.categories[0].amount === 0) {
-        locTrnsx.categories[0].amount = locTrnsx.amount;
+      if (locTrnsx.categories.length === 1 && locTrnsx.categories[0]?.amount === 0) {
+        locTrnsx.categories[0]!.amount = locTrnsx.amount;
       }
       locTrnsx.userId = props.userId;
       if (!locTrnsx.status) {

--- a/quasar/src/env.d.ts
+++ b/quasar/src/env.d.ts
@@ -5,3 +5,6 @@ declare namespace NodeJS {
     VUE_ROUTER_BASE: string | undefined;
   }
 }
+
+declare module "papaparse";
+declare module "file-saver";


### PR DESCRIPTION
## Summary
- declare papaparse and file-saver modules
- use Quasar QForm instead of Vuetify VForm
- relax `DisplayTransaction` typing and update usages
- ensure budget month assignments and balance calculations handle undefined
- clean up button icons and account option types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6852792d52d08329bed3f177ec6ca43c