### PR TITLE
Use Quasar screen for mobile detection

### DIFF
--- a/quasar/src/components/CategoryTransactions.vue
+++ b/quasar/src/components/CategoryTransactions.vue
@@ -146,6 +146,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue";
+import { useQuasar } from 'quasar';
 import { dataAccess } from "../dataAccess";
 import TransactionForm from "./TransactionForm.vue";
 import { BudgetCategory, Transaction, Budget } from "../types";
@@ -168,6 +169,7 @@ const emit = defineEmits<{
 
 const search = ref("");
 const budgetStore = useBudgetStore();
+const $q = useQuasar();
 const loading = ref(false);
 const showEditDialog = ref(false);
 const transactionToEdit = ref<Transaction | null>(null);
@@ -229,7 +231,7 @@ const progressPercentage = computed(() => {
   return Math.min(Math.max(rawPercentage, 0), 100);
 });
 
-const isMobile = computed(() => window.innerWidth < 960);
+const isMobile = computed(() => $q.screen.lt.md);
 
 const isIncome = computed(() => {
   return props.category.group === "Income";

--- a/quasar/src/components/MatchBankTransactionsDialog.vue
+++ b/quasar/src/components/MatchBankTransactionsDialog.vue
@@ -306,6 +306,7 @@
 <script setup lang="ts">
 import { ref, watch, computed, onMounted, nextTick } from "vue";
 import { Transaction, ImportedTransaction, Budget } from "../types";
+import { useQuasar } from 'quasar';
 import { toDollars, toCents, toBudgetMonth, adjustTransactionDate, todayISO } from "../utils/helpers";
 import { dataAccess } from "../dataAccess";
 import { useBudgetStore } from "../store/budget";
@@ -317,6 +318,7 @@ import { v4 as uuidv4 } from "uuid";
 
 const budgetStore = useBudgetStore();
 const familyStore = useFamilyStore();
+const $q = useQuasar();
 
 const props = defineProps<{
   showDialog: boolean;
@@ -405,7 +407,7 @@ const newTransaction = ref<Transaction>({
 } as Transaction);
 const newTransactionBudgetId = ref<string>(""); // Track budgetId for TransactionDialog
 
-const isMobile = computed(() => window.innerWidth < 960);
+const isMobile = computed(() => $q.screen.lt.md);
 
 const entityOptions = computed(() => {
   return (familyStore.family?.entities || []).map((entity) => ({

--- a/quasar/src/components/MatchBudgetTransactionDialog.vue
+++ b/quasar/src/components/MatchBudgetTransactionDialog.vue
@@ -76,6 +76,7 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
+import { useQuasar } from 'quasar';
 import { Transaction, ImportedTransaction, Account } from "../types";
 import { toDollars, toCents } from "../utils/helpers";
 
@@ -97,8 +98,9 @@ const selectedImportedTransaction = ref<string[]>([]);
 const searchAmount = ref<string>("");
 const searchMerchant = ref<string>("");
 const searchDateRange = ref<number>(4);
+const $q = useQuasar();
 
-const isMobile = computed(() => window.innerWidth < 960);
+const isMobile = computed(() => $q.screen.lt.md);
 
 const filteredImportedTransactions = computed(() => {
   let results = [...props.unmatchedImportedTransactions];

--- a/quasar/src/components/TransactionDialog.vue
+++ b/quasar/src/components/TransactionDialog.vue
@@ -28,8 +28,10 @@
 
 <script setup lang="ts">
 import { ref, watch, computed } from "vue";
+import { useQuasar } from 'quasar';
 import TransactionForm from "./TransactionForm.vue";
 import { Transaction } from "../types";
+const $q = useQuasar();
 
 const props = defineProps<{
   showDialog: boolean;
@@ -68,7 +70,7 @@ watch(
 );
 
 // Computed prop for mobile check
-const isMobile = computed(() => window.innerWidth < 960);
+const isMobile = computed(() => $q.screen.lt.md);
 
 function handleDialogClose(value: boolean) {
   emit("update:showDialog", value);

--- a/quasar/src/components/TransactionForm.vue
+++ b/quasar/src/components/TransactionForm.vue
@@ -178,6 +178,7 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch, reactive } from "vue";
+import { useQuasar } from 'quasar';
 import { dataAccess } from "../dataAccess";
 import { Budget, Transaction } from "../types";
 import { toCents, toDollars, todayISO, currentMonthISO } from "../utils/helpers";
@@ -189,6 +190,7 @@ import { useBudgetStore } from "../store/budget";
 
 const merchantStore = useMerchantStore();
 const budgetStore = useBudgetStore();
+const $q = useQuasar();
 
 const props = defineProps<{
   initialTransaction: Transaction;
@@ -243,7 +245,7 @@ const budget = ref<Budget | null>(null);
 const transactions = ref<Transaction[]>([]);
 const loading = ref(false);
 const intervals = ref(["Daily", "Weekly", "Bi-Weekly", "Monthly", "Quarterly", "Bi-Annually", "Yearly"]);
-const isMobile = computed(() => window.innerWidth < 960);
+const isMobile = computed(() => $q.screen.lt.md);
 
 const merchantNames = computed(() => merchantStore.merchantNames);
 

--- a/quasar/src/layouts/MainLayout.vue
+++ b/quasar/src/layouts/MainLayout.vue
@@ -76,7 +76,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
+import { useQuasar } from 'quasar';
 import type { User } from 'firebase/auth';
 import { useRouter } from 'vue-router';
 import version from '../version';
@@ -87,18 +88,18 @@ import { useFamilyStore } from '../store/family';
 const router = useRouter();
 const auth = useAuthStore();
 const familyStore = useFamilyStore();
+const $q = useQuasar();
 const currentTab = ref('/');
 
 // Reactive state
 const user = ref<User | null>(null);
 const avatarSrc = ref<string>('https://via.placeholder.com/36');
-const windowWidth = ref(window.innerWidth);
 const showOnboarding = ref(false);
 const showSignOutDialog = ref(false); // New dialog state
 
 // Computed properties
 const isLoginRoute = computed(() => router.currentRoute.value.path === '/login');
-const isMobile = computed(() => windowWidth.value < 960);
+const isMobile = computed(() => $q.screen.lt.md);
 const userEmail = computed(() => user.value?.email ?? 'Guest');
 const appVersion = version;
 
@@ -128,10 +129,6 @@ function promptSignOut() {
   showSignOutDialog.value = true; // Show confirmation dialog
 }
 
-function handleResize() {
-  windowWidth.value = window.innerWidth;
-}
-
 function completeOnboarding(_familyId: string) {
   showOnboarding.value = false;
 }
@@ -159,12 +156,8 @@ onMounted(async () => {
     void router.push('/login'); // Redirect to login if no user
   }
 
-  window.addEventListener('resize', handleResize);
 });
 
-onUnmounted(() => {
-  window.removeEventListener('resize', handleResize);
-});
 
 watch(
   () => auth.user,

--- a/quasar/src/pages/TransactionsPage.vue
+++ b/quasar/src/pages/TransactionsPage.vue
@@ -280,6 +280,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted, computed, watch } from "vue";
+import { useQuasar } from 'quasar';
 import { storeToRefs } from "pinia";
 import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
@@ -293,6 +294,7 @@ import { useBudgetStore } from "../store/budget";
 import { useFamilyStore } from "../store/family";
 import { useUIStore } from "../store/ui";
 import { v4 as uuidv4 } from "uuid";
+const $q = useQuasar();
 
 const budgetStore = useBudgetStore();
 const familyStore = useFamilyStore();
@@ -353,7 +355,7 @@ const matching = ref(false);
 const remainingImportedTransactions = ref<ImportedTransaction[]>([]);
 const pendingImportedTx = ref<ImportedTransaction | null>(null);
 const targetBudgetId = ref<string>("");
-const isMobile = computed(() => window.innerWidth < 960);
+const isMobile = computed(() => $q.screen.lt.md);
 
 const userId = computed(() => auth.currentUser?.uid || "");
 


### PR DESCRIPTION
## Summary
- rely on Quasar's screen service for detecting mobile view
- remove manual window size handling in MainLayout
- update dialogs and components to use `$q.screen.lt.md`

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test` *(fails: command not found)*
- `npm test` in quasar project

------
https://chatgpt.com/codex/tasks/task_b_68528c06e67083298b61261899102302