### PR TITLE
Fix icon set to use Google Material icons

### DIFF
--- a/quasar/quasar.config.ts
+++ b/quasar/quasar.config.ts
@@ -88,7 +88,7 @@ export default defineConfig((/* ctx */) => {
     framework: {
       config: {},
 
-      // iconSet: 'material-icons', // Quasar icon set
+      iconSet: 'material-icons', // Quasar icon set
       // lang: 'en-US', // Quasar language pack
 
       // For special cases outside of where the auto-import strategy can have an impact

--- a/quasar/src/components/CategoryTransactions.vue
+++ b/quasar/src/components/CategoryTransactions.vue
@@ -91,7 +91,7 @@
 
     <!-- Floating Action Button -->
     <q-fab
-      icon="mdi-plus"
+      icon="add"
       :app="true"
       color="primary"
       @click="$emit('add-transaction')"

--- a/quasar/src/components/MatchBankTransactionsDialog.vue
+++ b/quasar/src/components/MatchBankTransactionsDialog.vue
@@ -8,7 +8,7 @@
           <div class="col"><q-space></q-space></div>
           <div class="col-auto text-right">
             <q-btn color="error" @click="closeDialog(false)" :disabled="props.matching" variant="plain">
-              <q-icon>mdi-close</q-icon>
+              <q-icon>close</q-icon>
             </q-btn>
           </div>
         </div>
@@ -85,7 +85,7 @@
                       color="warning"
                       title="This budget transaction matches multiple bank transactions"
                     >
-                      mdi-alert
+                      warning
                     </q-icon>
                   </template>
                 </q-data-table>

--- a/quasar/src/components/TransactionForm.vue
+++ b/quasar/src/components/TransactionForm.vue
@@ -50,7 +50,7 @@
         <div v-for="(split, index) in locTrnsx.categories" :key="index">
           <q-row no-gutters>
             <q-col no-gutters cols="auto" class="form-col-label pr-2" :class="locTrnsx.categories.length > 1 ? '' : 'pb-5'">
-              <q-icon color="error" @click="removeSplit(index)">mdi-close</q-icon>
+              <q-icon color="error" @click="removeSplit(index)">close</q-icon>
             </q-col>
             <q-col>
               <q-combobox

--- a/quasar/src/components/TransactionRegistry.vue
+++ b/quasar/src/components/TransactionRegistry.vue
@@ -15,7 +15,7 @@
       </q-col>
       <q-col cols="auto" class="d-flex align-center">
         <q-btn color="primary" variant="plain" @click="refreshData" :loading="loading">
-          <q-icon start>mdi-refresh</q-icon>
+          <q-icon start>refresh</q-icon>
           Refresh
         </q-btn>
       </q-col>
@@ -91,7 +91,7 @@
         <q-row>
           <q-col cols="6" md="6">
             <q-text-field
-              append-inner-icon="mdi-magnify"
+              append-inner-icon="search"
               density="compact"
               label="Search"
               variant="outlined"
@@ -150,7 +150,7 @@
           <q-col>Transaction Registry</q-col>
           <q-col cols="auto">
             <q-btn variant="plain" @click="downloadCsv" :disabled="displayTransactions.length === 0">
-              <q-icon>mdi-download</q-icon>
+              <q-icon>download</q-icon>
               <q-tooltip activator="parent" location="top">Download CSV</q-tooltip>
             </q-btn>
           </q-col>
@@ -229,7 +229,7 @@
             @click.stop="confirmAction(item, 'Disconnect')"
             title="Disconnect Transaction"
           >
-            <q-icon>mdi-link-off</q-icon>
+            <q-icon>link_off</q-icon>
           </q-btn>
           <q-btn
             v-if="item.status != 'C' && item.id"
@@ -239,7 +239,7 @@
             @click.stop="confirmAction(item, 'Ignore')"
             title="Ignore Imported Transaction"
           >
-            <q-icon>mdi-eye-off-outline</q-icon>
+            <q-icon>visibility_off</q-icon>
           </q-btn>
           <q-btn
             v-if="item.status != 'C' && item.id"
@@ -249,7 +249,7 @@
             @click.stop="confirmAction(item, 'Delete')"
             title="Delete Imported Transaction"
           >
-            <q-icon>mdi-trash-can-outline</q-icon>
+            <q-icon>delete_outline</q-icon>
           </q-btn>
         </template>
       </q-data-table>

--- a/quasar/src/layouts/MainLayout.vue
+++ b/quasar/src/layouts/MainLayout.vue
@@ -104,13 +104,13 @@ const userEmail = computed(() => user.value?.email ?? 'Guest');
 const appVersion = version;
 
 const navItems = [
-  { title: 'Budget', path: '/', icon: 'mdi-turtle', desktop: true, mobile: true },
-  { title: 'Transactions', path: '/transactions', icon: 'mdi-format-list-bulleted', desktop: true, mobile: true },
-  { title: 'Accounts', path: '/accounts', icon: 'mdi-bank-outline', desktop: true, mobile: true },
-  { title: 'Reports', path: '/reports', icon: 'mdi-trending-up', desktop: true, mobile: false },
-  { title: 'Data Mgmt', path: '/data', icon: 'mdi-database-export-outline', desktop: true, mobile: false },
-  { title: 'Settings', path: '/settings', icon: 'mdi-account-group-outline', desktop: true, mobile: true },
-  { title: 'Logout', path: '', icon: 'mdi-logout', desktop: false, mobile: true },
+  { title: 'Budget', path: '/', icon: 'pie_chart', desktop: true, mobile: true },
+  { title: 'Transactions', path: '/transactions', icon: 'list', desktop: true, mobile: true },
+  { title: 'Accounts', path: '/accounts', icon: 'account_balance', desktop: true, mobile: true },
+  { title: 'Reports', path: '/reports', icon: 'trending_up', desktop: true, mobile: false },
+  { title: 'Data Mgmt', path: '/data', icon: 'storage', desktop: true, mobile: false },
+  { title: 'Settings', path: '/settings', icon: 'group', desktop: true, mobile: true },
+  { title: 'Logout', path: '', icon: 'logout', desktop: false, mobile: true },
 ];
 
 // Functions

--- a/quasar/src/pages/AccountsPage.vue
+++ b/quasar/src/pages/AccountsPage.vue
@@ -80,7 +80,7 @@
               </template>
               <template v-slot:item.actions="{ item }">
                 <q-btn icon density="compact" variant="plain" color="error" @click="confirmDeleteSnapshot(item.id)">
-                  <q-icon>mdi-trash-can-outline</q-icon>
+                  <q-icon>delete_outline</q-icon>
                 </q-btn>
               </template>
             </q-data-table>

--- a/quasar/src/pages/DashboardPage.vue
+++ b/quasar/src/pages/DashboardPage.vue
@@ -49,7 +49,7 @@
                 <div v-bind="props" class="month-selector no-wrap" :class="{ 'white--text': isMobile }">
                   <h1>
                     {{ formatMonth(currentMonth) }}
-                    <q-icon small>mdi-chevron-down</q-icon>
+                    <q-icon small>expand_more</q-icon>
                   </h1>
                 </div>
               </template>
@@ -57,7 +57,7 @@
                 <q-row no-gutters class="month-navigation">
                   <q-col cols="auto">
                     <q-btn icon small @click.stop="shiftMonths(-6)">
-                      <q-icon>mdi-chevron-left</q-icon>
+                      <q-icon>chevron_left</q-icon>
                     </q-btn>
                   </q-col>
                   <q-col class="text-center">
@@ -65,7 +65,7 @@
                   </q-col>
                   <q-col cols="auto">
                     <q-btn icon small @click.stop="shiftMonths(6)">
-                      <q-icon>mdi-chevron-right</q-icon>
+                      <q-icon>chevron_right</q-icon>
                     </q-btn>
                   </q-col>
                 </q-row>
@@ -89,10 +89,10 @@
                 <q-icon color="primary">edit</q-icon>
               </q-btn>
               <q-btn v-if="isEditing" icon class="mr-1" @click="isEditing = false" title="Cancel" variant="plain">
-                <q-icon>mdi-close</q-icon>
+                <q-icon>close</q-icon>
               </q-btn>
               <q-btn v-if="!isMobile && !isEditing" icon title="Delete Budget" variant="plain">
-                <q-icon color="error">mdi-trash-can-outline</q-icon>
+                <q-icon color="error">delete_outline</q-icon>
               </q-btn>
             </div>
           </div>
@@ -111,10 +111,10 @@
         </q-col>
         <q-col v-if="!isMobile || selectedCategory == null" cols="12" sm="6">
           <div class="my-2 bg-white rounded-10 pt-2 pr-3 pl-3 mb-4">
-            <q-text-field append-inner-icon="mdi-magnify" density="compact" label="Search" variant="plain" single-line v-model="search"></q-text-field>
+            <q-text-field append-inner-icon="search" density="compact" label="Search" variant="plain" single-line v-model="search"></q-text-field>
           </div>
         </q-col>
-        <q-fab v-if="isMobile && !selectedCategory" icon="mdi-plus" variant="plain" color="white" app location="top right" @click="addTransaction"></q-fab>
+        <q-fab v-if="isMobile && !selectedCategory" icon="add" variant="plain" color="white" app location="top right" @click="addTransaction"></q-fab>
       </q-row>
 
       <q-row>
@@ -140,7 +140,7 @@
                       density="compact"
                       class="mt-2"
                       @keyup.enter="addMerchant"
-                      append-inner-icon="mdi-plus"
+                      append-inner-icon="add"
                       @click:append-inner="addMerchant"
                     ></q-text-field>
                   </q-col>
@@ -168,7 +168,7 @@
                     <q-checkbox v-model="cat.isFund" label="Is Fund?" density="compact"></q-checkbox>
                   </q-col>
                   <q-col cols="12" sm="1" class="pa-2">
-                    <q-btn color="error" icon="mdi-close" @click="removeCategory(index)" variant="plain"></q-btn>
+                    <q-btn color="error" icon="close" @click="removeCategory(index)" variant="plain"></q-btn>
                   </q-col>
                 </q-row>
 
@@ -231,7 +231,7 @@
                         @touchstart="startTouch(item, 'name')"
                         @touchend="endTouch"
                       >
-                        <q-icon v-if="item.isFund" small class="mr-1" color="primary">mdi-piggy-bank-outline</q-icon>
+                        <q-icon v-if="item.isFund" small class="mr-1" color="primary">savings</q-icon>
                         {{ item.name }}
                       </q-col>
                       <q-col v-else>

--- a/quasar/src/pages/SettingsPage.vue
+++ b/quasar/src/pages/SettingsPage.vue
@@ -55,12 +55,12 @@
                   </q-col>
                   <q-col cols="auto">
                     <q-btn variant="plain" color="primary" icon @click="openEditEntityDialog(entity)">
-                      <q-icon>mdi-pencil</q-icon>
+                      <q-icon>edit</q-icon>
                     </q-btn>
                   </q-col>
                   <q-col cols="auto">
                     <q-btn variant="plain" icon @click="confirmDeleteEntity(entity)" color="error">
-                      <q-icon>mdi-trash-can-outline</q-icon>
+                      <q-icon>delete_outline</q-icon>
                     </q-btn>
                   </q-col>
                 </q-row>
@@ -94,7 +94,7 @@
                       @click.stop="confirmDeleteTransactionDoc(item)"
                       title="Delete Transaction Document"
                     >
-                      <q-icon>mdi-trash-can-outline</q-icon>
+                      <q-icon>delete_outline</q-icon>
                     </q-btn>
                   </template>
                 </q-data-table>
@@ -120,7 +120,7 @@
                   </template>
                   <template v-slot:item.actions="{ item }">
                     <q-btn icon density="compact" variant="plain" color="error" @click.stop="confirmDeleteBudget(item)" title="Delete Budget">
-                      <q-icon>mdi-trash-can-outline</q-icon>
+                      <q-icon>delete_outline</q-icon>
                     </q-btn>
                   </template>
                 </q-data-table>

--- a/quasar/src/pages/SetupWizardPage.vue
+++ b/quasar/src/pages/SetupWizardPage.vue
@@ -11,8 +11,8 @@
           :complete="isStepComplete(step.value)"
           :title="step.title"
           :icon="getStepIcon(step.value)"
-          edit-icon="mdi-pencil"
-          error-icon="mdi-alert-circle"
+          edit-icon="edit"
+          error-icon="error"
         >
         </q-stepper-item>
       </template>
@@ -43,7 +43,7 @@
                     <q-row class="full-width align-center">
                       <q-col class="text-h6">Saved Entities</q-col>
                       <q-col cols="auto" class="text-right">
-                        <q-btn density="compact" variant="plain" icon="mdi-plus" color="success" @click="initNewEntity" aria-label="Add New Entity"></q-btn>
+                        <q-btn density="compact" variant="plain" icon="add" color="success" @click="initNewEntity" aria-label="Add New Entity"></q-btn>
                       </q-col>
                     </q-row>
                     <q-item
@@ -251,15 +251,15 @@ const isStepEditable = (stepValue: string): boolean => {
 // Step Icons
 function getStepIcon(stepValue: string): string {
   const icons = {
-    family: "mdi-account-group",
-    entities: "mdi-domain",
-    "account-bank": "mdi-bank",
-    "account-creditcard": "mdi-credit-card",
-    "account-investment": "mdi-chart-line",
-    "account-property": "mdi-home",
-    "account-loan": "mdi-handshake",
+    family: "group",
+    entities: "domain",
+    "account-bank": "account_balance",
+    "account-creditcard": "credit_card",
+    "account-investment": "show_chart",
+    "account-property": "home",
+    "account-loan": "handshake",
   };
-  return icons[stepValue] || "mdi-circle";
+  return icons[stepValue] || "circle";
 }
 
 watch(currentStepValue, (newValue) => {

--- a/quasar/src/pages/TransactionsPage.vue
+++ b/quasar/src/pages/TransactionsPage.vue
@@ -47,7 +47,7 @@
               </q-col>
               <q-col cols="12" md="4">
                 <q-text-field
-                  append-inner-icon="mdi-magnify"
+                  append-inner-icon="search"
                   density="compact"
                   label="Search"
                   variant="outlined"
@@ -165,9 +165,9 @@
                       small
                       @click.stop="selectBudgetTransactionToMatch(transaction)"
                       title="Match Transaction"
-                      >mdi-link</q-icon
+                      >link</q-icon
                     >
-                    <q-icon small @click.stop="deleteTransaction(transaction.id)" title="Delete Entry" color="error" class="ml-2">mdi-trash-can-outline</q-icon>
+                    <q-icon small @click.stop="deleteTransaction(transaction.id)" title="Delete Entry" color="error" class="ml-2">delete_outline</q-icon>
                   </q-col>
                 </q-row>
               </template>
@@ -193,9 +193,9 @@
                       </q-col>
                       <q-col cols="1" class="text-right">
                         <q-btn v-if="transaction.status !== 'C'" icon small @click.stop="selectBudgetTransactionToMatch(transaction)" title="Match Transaction">
-                          <q-icon color="primary">mdi-link</q-icon>
+                          <q-icon color="primary">link</q-icon>
                         </q-btn>
-                        <q-icon small @click.stop="deleteTransaction(transaction.id)" title="Delete Entry" color="error">mdi-trash-can-outline</q-icon>
+                        <q-icon small @click.stop="deleteTransaction(transaction.id)" title="Delete Entry" color="error">delete_outline</q-icon>
                       </q-col>
                     </q-row>
                     <q-row no-gutters class="mt-1 text-caption text-grey">


### PR DESCRIPTION
## Summary
- update Quasar config to explicitly use `material-icons`
- replace `mdi-` icons with matching Google Material icons across components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68528e8ce9308329be419879eecb93fd