### PR TITLE
Add entity menu selector

### DIFF
--- a/app/src/components/EntitySelector.vue
+++ b/app/src/components/EntitySelector.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <v-menu v-if="showMenu" v-model="menuOpen" offset-y>
+      <template #activator="{ props }">
+        <div v-bind="props" class="entity-selector no-wrap">
+          <h1>
+            {{ currentEntityName }}
+            <v-icon small>mdi-chevron-down</v-icon>
+          </h1>
+        </div>
+      </template>
+      <v-list class="entity-menu">
+        <v-list-item v-for="option in entityOptions" :key="option.id" @click="selectEntity(option.id)">
+          <v-list-item-title>{{ option.name }}</v-list-item-title>
+        </v-list-item>
+      </v-list>
+    </v-menu>
+    <div v-else class="entity-selector no-wrap">
+      <h1>{{ currentEntityName }}</h1>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useFamilyStore } from '../store/family';
+
+const emit = defineEmits<{ (e: 'change', value: string): void }>();
+
+const familyStore = useFamilyStore();
+
+const menuOpen = ref(false);
+const entities = computed(() => familyStore.family?.entities || []);
+
+const entityOptions = computed(() => {
+  const opts = entities.value.map(e => ({ id: e.id, name: e.name }));
+  return [{ id: '', name: 'All Entities' }, ...opts];
+});
+
+const currentEntityName = computed(() => {
+  if (!familyStore.selectedEntityId) return 'All Entities';
+  return entities.value.find(e => e.id === familyStore.selectedEntityId)?.name || 'All Entities';
+});
+
+const showMenu = computed(() => entities.value.length > 1);
+
+function selectEntity(id: string) {
+  familyStore.selectEntity(id);
+  menuOpen.value = false;
+  emit('change', id);
+}
+</script>
+
+<style scoped>
+.entity-selector {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: rgb(var(--v-theme-primary));
+}
+.entity-menu {
+  padding: 8px;
+  min-width: 200px;
+}
+</style>

--- a/app/src/views/DashboardView.vue
+++ b/app/src/views/DashboardView.vue
@@ -30,19 +30,8 @@
     <div v-else>
       <v-row :class="isMobile ? '' : 'pe-16'" no-gutters>
         <v-col :cols="isMobile ? '8' : '12'">
-          <!-- Entity Dropdown -->
-          <v-select
-            v-model="familyStore.selectedEntityId"
-            :items="entityOptions"
-            item-title="name"
-            item-value="id"
-            label="Select Entity"
-            variant="outlined"
-            density="compact"
-            clearable
-            @update:modelValue="loadBudgets"
-            class="entity-select"
-          ></v-select>
+        <!-- Entity Selector -->
+        <EntitySelector @change="loadBudgets" class="mb-2" />
           <div class="d-flex align-center">
             <v-menu offset-y :close-on-content-click="false" v-model="menuOpen">
               <template v-slot:activator="{ props }">
@@ -370,6 +359,7 @@ import { dataAccess } from "../dataAccess";
 import CurrencyInput from "../components/CurrencyInput.vue";
 import CategoryTransactions from "../components/CategoryTransactions.vue";
 import TransactionForm from "../components/TransactionForm.vue";
+import EntitySelector from "../components/EntitySelector.vue";
 import { Transaction, Budget, IncomeTarget, BudgetCategoryTrx, BudgetCategory, Entity } from "../types";
 import version from "../version";
 import { toDollars, toCents, formatCurrency, adjustTransactionDate, todayISO, currentMonthISO } from "../utils/helpers";
@@ -454,14 +444,6 @@ const inlineEdit = ref({
 const isMobile = computed(() => window.innerWidth < 960);
 
 // Entity-related computed properties
-const entityOptions = computed(() => {
-  const options = (familyStore.family?.entities || []).map((entity) => ({
-    id: entity.id,
-    name: entity.name,
-  }));
-  return [{ id: "", name: "All Entities" }, ...options];
-});
-
 const selectedEntity = computed(() => {
   return familyStore.family?.entities?.find((e) => e.id === familyStore.selectedEntityId);
 });
@@ -1392,10 +1374,17 @@ h1 {
   font-size: 1.3em;
   text-wrap: nowrap;
 }
-.entity-select .v-field__input {
-  font-size: 1.6rem;
+.entity-selector {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.5rem;
   font-weight: bold;
   color: rgb(var(--v-theme-primary));
+}
+.entity-menu {
+  padding: 8px;
+  min-width: 200px;
 }
 .search-container {
   max-width: 400px;

--- a/app/src/views/TransactionsView.vue
+++ b/app/src/views/TransactionsView.vue
@@ -33,17 +33,7 @@
           <v-card-text>
             <v-row>
               <v-col cols="12" md="4">
-                <v-select
-                  v-model="familyStore.selectedEntityId"
-                  :items="entityOptions"
-                  item-title="name"
-                  item-value="id"
-                  label="Select Entity"
-                  variant="outlined"
-                  density="compact"
-                  clearable
-                  @update:modelValue="loadBudgets"
-                ></v-select>
+                <EntitySelector @change="loadBudgets" />
               </v-col>
               <v-col cols="12" md="4">
                 <v-text-field
@@ -287,6 +277,7 @@ import TransactionDialog from "../components/TransactionDialog.vue";
 import MatchBankTransactionsDialog from "../components/MatchBankTransactionsDialog.vue";
 import MatchBudgetTransactionDialog from "../components/MatchBudgetTransactionDialog.vue";
 import TransactionRegistry from "../components/TransactionRegistry.vue";
+import EntitySelector from "../components/EntitySelector.vue";
 import { Transaction, BudgetInfo, ImportedTransaction, Account, Entity } from "../types";
 import { formatDateLong, toDollars, toCents, formatCurrency, toBudgetMonth, todayISO } from "../utils/helpers";
 import { useBudgetStore } from "../store/budget";
@@ -356,14 +347,6 @@ const targetBudgetId = ref<string>("");
 const isMobile = computed(() => window.innerWidth < 960);
 
 const userId = computed(() => auth.currentUser?.uid || "");
-
-const entityOptions = computed(() => {
-  const options = (familyStore.family?.entities || []).map((entity) => ({
-    id: entity.id,
-    name: entity.name,
-  }));
-  return [{ id: "", name: "All Entities" }, ...options];
-});
 
 const potentialDuplicateIds = computed(() => {
   const ids = new Set<string>();
@@ -789,6 +772,18 @@ function applyFilters() {
 </script>
 
 <style scoped>
+.entity-selector {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: rgb(var(--v-theme-primary));
+}
+.entity-menu {
+  padding: 8px;
+  min-width: 200px;
+}
 .transaction-item {
   border-bottom: 1px solid #e0e0e0;
 }

--- a/quasar/src/components/EntitySelector.vue
+++ b/quasar/src/components/EntitySelector.vue
@@ -1,0 +1,71 @@
+<template>
+  <div>
+    <template v-if="showMenu">
+      <q-menu v-model="menuOpen" offset-y>
+        <template #activator="{ props }">
+          <div v-bind="props" class="entity-selector no-wrap">
+            <h1>
+              {{ currentEntityName }}
+              <q-icon small>expand_more</q-icon>
+            </h1>
+          </div>
+        </template>
+        <q-list class="entity-menu">
+          <q-item v-for="option in entityOptions" :key="option.id" clickable @click="selectEntity(option.id)">
+            <q-item-section>{{ option.name }}</q-item-section>
+          </q-item>
+        </q-list>
+      </q-menu>
+    </template>
+    <template v-else>
+      <div class="entity-selector no-wrap">
+        <h1>{{ currentEntityName }}</h1>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useFamilyStore } from '../store/family';
+
+const emit = defineEmits<{ (e: 'change', value: string): void }>();
+
+const familyStore = useFamilyStore();
+
+const menuOpen = ref(false);
+const entities = computed(() => familyStore.family?.entities || []);
+
+const entityOptions = computed(() => {
+  const opts = entities.value.map(e => ({ id: e.id, name: e.name }));
+  return [{ id: '', name: 'All Entities' }, ...opts];
+});
+
+const currentEntityName = computed(() => {
+  if (!familyStore.selectedEntityId) return 'All Entities';
+  return entities.value.find(e => e.id === familyStore.selectedEntityId)?.name || 'All Entities';
+});
+
+const showMenu = computed(() => entities.value.length > 1);
+
+function selectEntity(id: string) {
+  familyStore.selectEntity(id);
+  menuOpen.value = false;
+  emit('change', id);
+}
+</script>
+
+<style scoped>
+.entity-selector {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: rgb(var(--v-theme-primary));
+}
+.entity-menu {
+  padding: 8px;
+  min-width: 200px;
+}
+</style>

--- a/quasar/src/pages/DashboardPage.vue
+++ b/quasar/src/pages/DashboardPage.vue
@@ -31,18 +31,7 @@
       <div class="row" :class="isMobile ? 'pa-2' : 'pe-16'">
         <div class="col-12">
           <!-- Entity Dropdown -->
-          <q-select
-            v-model="familyStore.selectedEntityId"
-            :items="entityOptions"
-            item-title="name"
-            item-value="id"
-            label="Select Entity"
-            variant="outlined"
-            density="compact"
-            clearable
-            @update:modelValue="loadBudgets"
-            class="entity-select mb-2"
-          ></q-select>
+          <EntitySelector @change="loadBudgets" class="mb-2" />
           <div class="d-flex align-center">
             <q-menu offset-y :close-on-content-click="false" v-model="menuOpen">
               <template v-slot:activator="{ props }">
@@ -369,6 +358,7 @@ import { dataAccess } from '../dataAccess';
 import CurrencyInput from '../components/CurrencyInput.vue';
 import CategoryTransactions from '../components/CategoryTransactions.vue';
 import TransactionForm from '../components/TransactionForm.vue';
+import EntitySelector from '../components/EntitySelector.vue';
 import type { Transaction, Budget, IncomeTarget, BudgetCategoryTrx, BudgetCategory } from '../types';
 import { Entity } from '../types';
 import version from '../version';
@@ -1398,10 +1388,17 @@ h1 {
   font-size: 1.3em;
   text-wrap: nowrap;
 }
-.entity-select .v-field__input {
-  font-size: 1.6rem;
+.entity-selector {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.5rem;
   font-weight: bold;
   color: rgb(var(--v-theme-primary));
+}
+.entity-menu {
+  padding: 8px;
+  min-width: 200px;
 }
 .search-container {
   max-width: 400px;

--- a/quasar/src/pages/TransactionsPage.vue
+++ b/quasar/src/pages/TransactionsPage.vue
@@ -33,17 +33,7 @@
           <q-card-section>
             <div class="row">
               <div class="col col-12 col-md-4">
-                <q-select
-                  v-model="familyStore.selectedEntityId"
-                  :items="entityOptions"
-                  item-title="name"
-                  item-value="id"
-                  label="Select Entity"
-                  variant="outlined"
-                  density="compact"
-                  clearable
-                  @update:modelValue="loadBudgets"
-                ></q-select>
+                <EntitySelector @change="loadBudgets" />
               </div>
               <div class="col col-12 col-md-4">
                 <q-text-field
@@ -288,6 +278,7 @@ import TransactionDialog from "../components/TransactionDialog.vue";
 import MatchBankTransactionsDialog from "../components/MatchBankTransactionsDialog.vue";
 import MatchBudgetTransactionDialog from "../components/MatchBudgetTransactionDialog.vue";
 import TransactionRegistry from "../components/TransactionRegistry.vue";
+import EntitySelector from "../components/EntitySelector.vue";
 import { Transaction, BudgetInfo, ImportedTransaction, Account, Entity } from "../types";
 import { formatDateLong, toDollars, toCents, formatCurrency, toBudgetMonth, todayISO } from "../utils/helpers";
 import { useBudgetStore } from "../store/budget";
@@ -793,5 +784,13 @@ function applyFilters() {
 <style scoped>
 .transaction-item {
   border-bottom: 1px solid #e0e0e0;
+}
+.entity-selector {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: rgb(var(--v-theme-primary));
 }
 </style>


### PR DESCRIPTION
## Summary
- add `EntitySelector` component for Vuetify app
- swap v-selects for menu selector in Dashboard and Transactions views
- style the selector like the budget selector

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' or 'vue-cli-service')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685466ec69a88329bbc9bd1e5d663905