### PR TITLE
Add mobile filter accordion and layout tweaks

### DIFF
--- a/app/src/views/TransactionsView.vue
+++ b/app/src/views/TransactionsView.vue
@@ -69,51 +69,107 @@
               </v-col>
             </v-row>
 
-            <v-row no-gutters>
-              <v-col cols="12" md="2">
-                <v-text-field v-model="entriesFilterMerchant" label="Merchant" variant="outlined" density="compact" @input="applyFilters"></v-text-field>
-              </v-col>
-              <v-col cols="12" md="2">
-                <v-text-field
-                  v-model="entriesFilterAmount"
-                  label="Amount"
-                  type="number"
-                  variant="outlined"
-                  density="compact"
-                  @input="applyFilters"
-                ></v-text-field>
-              </v-col>
-              <v-col cols="12" md="2">
-                <v-text-field v-model="entriesFilterNote" label="Note/Memo" variant="outlined" density="compact" @input="applyFilters"></v-text-field>
-              </v-col>
-              <v-col cols="12" md="2">
-                <v-text-field
-                  v-model="entriesFilterDate"
-                  label="Date"
-                  type="date"
-                  variant="outlined"
-                  density="compact"
-                  :clearable="true"
-                  @input="applyFilters"
-                ></v-text-field>
-              </v-col>
-              <v-col cols="12" md="2">
-                <v-text-field v-model="entriesFilterStatus" label="Status" variant="outlined" density="compact" @input="applyFilters"></v-text-field>
-              </v-col>
-              <v-col cols="12" md="2">
-                <v-select
-                  v-model="entriesFilterAccount"
-                  :items="availableAccounts"
-                  item-title="name"
-                  item-value="id"
-                  label="Account"
-                  variant="outlined"
-                  density="compact"
-                  clearable
-                  @update:modelValue="applyFilters"
-                ></v-select>
-              </v-col>
-            </v-row>
+            <template v-if="!isMobile">
+              <v-row no-gutters>
+                <v-col cols="12" md="2">
+                  <v-text-field v-model="entriesFilterMerchant" label="Merchant" variant="outlined" density="compact" @input="applyFilters"></v-text-field>
+                </v-col>
+                <v-col cols="12" md="2">
+                  <v-text-field
+                    v-model="entriesFilterAmount"
+                    label="Amount"
+                    type="number"
+                    variant="outlined"
+                    density="compact"
+                    @input="applyFilters"
+                  ></v-text-field>
+                </v-col>
+                <v-col cols="12" md="2">
+                  <v-text-field v-model="entriesFilterNote" label="Note/Memo" variant="outlined" density="compact" @input="applyFilters"></v-text-field>
+                </v-col>
+                <v-col cols="12" md="2">
+                  <v-text-field
+                    v-model="entriesFilterDate"
+                    label="Date"
+                    type="date"
+                    variant="outlined"
+                    density="compact"
+                    :clearable="true"
+                    @input="applyFilters"
+                  ></v-text-field>
+                </v-col>
+                <v-col cols="12" md="2">
+                  <v-text-field v-model="entriesFilterStatus" label="Status" variant="outlined" density="compact" @input="applyFilters"></v-text-field>
+                </v-col>
+                <v-col cols="12" md="2">
+                  <v-select
+                    v-model="entriesFilterAccount"
+                    :items="availableAccounts"
+                    item-title="name"
+                    item-value="id"
+                    label="Account"
+                    variant="outlined"
+                    density="compact"
+                    clearable
+                    @update:modelValue="applyFilters"
+                  ></v-select>
+                </v-col>
+              </v-row>
+            </template>
+            <template v-else>
+              <v-expansion-panels>
+                <v-expansion-panel>
+                  <v-expansion-panel-title>More Filters</v-expansion-panel-title>
+                  <v-expansion-panel-text>
+                    <v-row no-gutters>
+                      <v-col cols="12" md="2">
+                        <v-text-field v-model="entriesFilterMerchant" label="Merchant" variant="outlined" density="compact" @input="applyFilters"></v-text-field>
+                      </v-col>
+                      <v-col cols="12" md="2">
+                        <v-text-field
+                          v-model="entriesFilterAmount"
+                          label="Amount"
+                          type="number"
+                          variant="outlined"
+                          density="compact"
+                          @input="applyFilters"
+                        ></v-text-field>
+                      </v-col>
+                      <v-col cols="12" md="2">
+                        <v-text-field v-model="entriesFilterNote" label="Note/Memo" variant="outlined" density="compact" @input="applyFilters"></v-text-field>
+                      </v-col>
+                      <v-col cols="12" md="2">
+                        <v-text-field
+                          v-model="entriesFilterDate"
+                          label="Date"
+                          type="date"
+                          variant="outlined"
+                          density="compact"
+                          :clearable="true"
+                          @input="applyFilters"
+                        ></v-text-field>
+                      </v-col>
+                      <v-col cols="12" md="2">
+                        <v-text-field v-model="entriesFilterStatus" label="Status" variant="outlined" density="compact" @input="applyFilters"></v-text-field>
+                      </v-col>
+                      <v-col cols="12" md="2">
+                        <v-select
+                          v-model="entriesFilterAccount"
+                          :items="availableAccounts"
+                          item-title="name"
+                          item-value="id"
+                          label="Account"
+                          variant="outlined"
+                          density="compact"
+                          clearable
+                          @update:modelValue="applyFilters"
+                        ></v-select>
+                      </v-col>
+                    </v-row>
+                  </v-expansion-panel-text>
+                </v-expansion-panel>
+              </v-expansion-panels>
+            </template>
           </v-card-text>
         </v-card>
 
@@ -168,14 +224,11 @@
               <template v-else>
                 <v-card>
                   <v-card-item>
-                    <v-row no-gutters class="align-center">
-                      <v-col cols="3" class="text-caption">
-                        {{ formatDateLong(transaction.date) }}
-                      </v-col>
+                    <v-row no-gutters>
                       <v-col class="font-weight-bold">
                         {{ transaction.merchant }}
                       </v-col>
-                      <v-col cols="auto" class="text-right">
+                      <v-col class="text-right">
                         <div :class="transaction.isIncome ? 'text-success' : ''">
                           {{ formatCurrency(toDollars(toCents(transaction.amount))) }}
                           <span v-if="transaction.status === 'C'" class="text-success font-weight-bold" title="Cleared">
@@ -183,23 +236,33 @@
                           </span>
                         </div>
                       </v-col>
-                      <v-col cols="1" class="text-right">
+                    </v-row>
+                    <v-row no-gutters class="text-caption">
+                      <v-col>
+                        {{ formatDateLong(transaction.date) }}
+                      </v-col>
+                      <v-col class="text-right">
                         <v-btn v-if="transaction.status !== 'C'" icon small @click.stop="selectBudgetTransactionToMatch(transaction)" title="Match Transaction">
                           <v-icon color="primary">mdi-link</v-icon>
                         </v-btn>
                         <v-icon small @click.stop="deleteTransaction(transaction.id)" title="Delete Entry" color="error">mdi-trash-can-outline</v-icon>
                       </v-col>
                     </v-row>
-                    <v-row no-gutters class="mt-1 text-caption text-grey">
-                      <v-col cols="12">Entity: {{ getEntityName(transaction.entityId || transaction.budgetId) }}</v-col>
-                      <v-col cols="12" v-if="transaction.notes"> Notes: {{ transaction.notes }} </v-col>
-                      <v-col cols="12" v-if="transaction.categories.length > 1"> Split: {{ formatCategories(transaction.categories) }} </v-col>
-                      <v-col cols="12" v-if="transaction.status === 'C'">
+                    <v-row v-if="transaction.notes" no-gutters class="text-caption text-grey">
+                      <v-col cols="12"> Notes: {{ transaction.notes }} </v-col>
+                    </v-row>
+                    <v-row v-if="transaction.categories.length > 1" no-gutters class="text-caption text-grey">
+                      <v-col cols="12"> Split: {{ formatCategories(transaction.categories) }} </v-col>
+                    </v-row>
+                    <v-row v-if="transaction.status === 'C'" no-gutters class="text-caption text-grey">
+                      <v-col cols="12">
                         Imported: {{ transaction.accountSource || "N/A" }}
                         {{ getAccountName(transaction.accountNumber) }}
                         {{ transaction.postedDate ? `@ ${transaction.postedDate}` : "" }}
                       </v-col>
-                      <v-col cols="12" v-if="transaction.recurring" class="text-primary"> Repeats: {{ transaction.recurringInterval }} </v-col>
+                    </v-row>
+                    <v-row v-if="transaction.recurring" no-gutters class="text-caption text-primary">
+                      <v-col cols="12"> Repeats: {{ transaction.recurringInterval }} </v-col>
                     </v-row>
                   </v-card-item>
                 </v-card>

--- a/quasar/src/pages/TransactionsPage.vue
+++ b/quasar/src/pages/TransactionsPage.vue
@@ -67,51 +67,106 @@
               </div>
             </div>
 
-            <div class="row">
-              <div class="col col-12 col-md-2">
-                <q-text-field v-model="entriesFilterMerchant" label="Merchant" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+            <template v-if="!isMobile">
+              <div class="row">
+                <div class="col col-12 col-md-2">
+                  <q-text-field v-model="entriesFilterMerchant" label="Merchant" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+                </div>
+                <div class="col col-12 col-md-2">
+                  <q-text-field
+                    v-model="entriesFilterAmount"
+                    label="Amount"
+                    type="number"
+                    variant="outlined"
+                    density="compact"
+                    @input="applyFilters"
+                  ></q-text-field>
+                </div>
+                <div class="col col-12 col-md-2">
+                  <q-text-field v-model="entriesFilterNote" label="Note/Memo" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+                </div>
+                <div class="col col-12 col-md-2">
+                  <q-text-field
+                    v-model="entriesFilterDate"
+                    label="Date"
+                    type="date"
+                    variant="outlined"
+                    density="compact"
+                    :clearable="true"
+                    @input="applyFilters"
+                  ></q-text-field>
+                </div>
+                <div class="col col-12 col-md-2">
+                  <q-text-field v-model="entriesFilterStatus" label="Status" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+                </div>
+                <div class="col col-12 col-md-2">
+                  <q-select
+                    v-model="entriesFilterAccount"
+                    :items="availableAccounts"
+                    item-title="name"
+                    item-value="id"
+                    label="Account"
+                    variant="outlined"
+                    density="compact"
+                    clearable
+                    @update:modelValue="applyFilters"
+                  ></q-select>
+                </div>
               </div>
-              <div class="col col-12 col-md-2">
-                <q-text-field
-                  v-model="entriesFilterAmount"
-                  label="Amount"
-                  type="number"
-                  variant="outlined"
-                  density="compact"
-                  @input="applyFilters"
-                ></q-text-field>
-              </div>
-              <div class="col col-12 col-md-2">
-                <q-text-field v-model="entriesFilterNote" label="Note/Memo" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
-              </div>
-              <div class="col col-12 col-md-2">
-                <q-text-field
-                  v-model="entriesFilterDate"
-                  label="Date"
-                  type="date"
-                  variant="outlined"
-                  density="compact"
-                  :clearable="true"
-                  @input="applyFilters"
-                ></q-text-field>
-              </div>
-              <div class="col col-12 col-md-2">
-                <q-text-field v-model="entriesFilterStatus" label="Status" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
-              </div>
-              <div class="col col-12 col-md-2">
-                <q-select
-                  v-model="entriesFilterAccount"
-                  :items="availableAccounts"
-                  item-title="name"
-                  item-value="id"
-                  label="Account"
-                  variant="outlined"
-                  density="compact"
-                  clearable
-                  @update:modelValue="applyFilters"
-                ></q-select>
-              </div>
-            </div>
+            </template>
+            <template v-else>
+              <q-expansion-panels>
+                <q-expansion-panel title="More Filters">
+                  <q-expansion-panel-text>
+                    <div class="row">
+                      <div class="col col-12 col-md-2">
+                        <q-text-field v-model="entriesFilterMerchant" label="Merchant" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+                      </div>
+                      <div class="col col-12 col-md-2">
+                        <q-text-field
+                          v-model="entriesFilterAmount"
+                          label="Amount"
+                          type="number"
+                          variant="outlined"
+                          density="compact"
+                          @input="applyFilters"
+                        ></q-text-field>
+                      </div>
+                      <div class="col col-12 col-md-2">
+                        <q-text-field v-model="entriesFilterNote" label="Note/Memo" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+                      </div>
+                      <div class="col col-12 col-md-2">
+                        <q-text-field
+                          v-model="entriesFilterDate"
+                          label="Date"
+                          type="date"
+                          variant="outlined"
+                          density="compact"
+                          :clearable="true"
+                          @input="applyFilters"
+                        ></q-text-field>
+                      </div>
+                      <div class="col col-12 col-md-2">
+                        <q-text-field v-model="entriesFilterStatus" label="Status" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+                      </div>
+                      <div class="col col-12 col-md-2">
+                        <q-select
+                          v-model="entriesFilterAccount"
+                          :items="availableAccounts"
+                          item-title="name"
+                          item-value="id"
+                          label="Account"
+                          variant="outlined"
+                          density="compact"
+                          clearable
+                          @update:modelValue="applyFilters"
+                        ></q-select>
+                      </div>
+                    </div>
+                  </q-expansion-panel-text>
+                </q-expansion-panel>
+              </q-expansion-panels>
+            </template>
           </q-card-section>
         </q-card>
 
@@ -166,14 +221,11 @@
               <template v-else>
                 <q-card>
                   <q-card-item>
-                    <div class="row align-center no-gutters"  >
-                      <div class="col text-caption col-3" >
-                        {{ formatDateLong(transaction.date) }}
-                      </div>
-                      <div class="col font-weight-bold" >
+                    <div class="row no-gutters">
+                      <div class="col font-weight-bold">
                         {{ transaction.merchant }}
                       </div>
-                      <div class="col text-right col-auto" >
+                      <div class="col text-right">
                         <div :class="transaction.isIncome ? 'text-success' : ''">
                           {{ formatCurrency(toDollars(toCents(transaction.amount))) }}
                           <span v-if="transaction.status === 'C'" class="text-success font-weight-bold" title="Cleared">
@@ -181,23 +233,33 @@
                           </span>
                         </div>
                       </div>
-                      <div class="col text-right col-1" >
+                    </div>
+                    <div class="row text-caption no-gutters">
+                      <div class="col">
+                        {{ formatDateLong(transaction.date) }}
+                      </div>
+                      <div class="col text-right">
                         <q-btn v-if="transaction.status !== 'C'" icon small @click.stop="selectBudgetTransactionToMatch(transaction)" title="Match Transaction">
                           <q-icon color="primary">link</q-icon>
                         </q-btn>
                         <q-icon small @click.stop="deleteTransaction(transaction.id)" title="Delete Entry" color="error">delete_outline</q-icon>
                       </div>
                     </div>
-                    <div class="row mt-1 text-caption text-grey no-gutters"  >
-                      <div class="col col-12">Entity: {{ getEntityName(transaction.entityId || transaction.budgetId) }}</div>
-                      <div class="col col-12" v-if="transaction.notes"> Notes: {{ transaction.notes }} </div>
-                      <div class="col col-12" v-if="transaction.categories.length > 1"> Split: {{ formatCategories(transaction.categories) }} </div>
-                      <div class="col col-12" v-if="transaction.status === 'C'">
+                    <div class="row text-caption text-grey no-gutters" v-if="transaction.notes">
+                      <div class="col col-12"> Notes: {{ transaction.notes }} </div>
+                    </div>
+                    <div class="row text-caption text-grey no-gutters" v-if="transaction.categories.length > 1">
+                      <div class="col col-12"> Split: {{ formatCategories(transaction.categories) }} </div>
+                    </div>
+                    <div class="row text-caption text-grey no-gutters" v-if="transaction.status === 'C'">
+                      <div class="col col-12">
                         Imported: {{ transaction.accountSource || "N/A" }}
                         {{ getAccountName(transaction.accountNumber) }}
                         {{ transaction.postedDate ? `@ ${transaction.postedDate}` : "" }}
                       </div>
-                      <div class="col text-primary col-12" v-if="transaction.recurring" > Repeats: {{ transaction.recurringInterval }} </div>
+                    </div>
+                    <div class="row text-primary text-caption no-gutters" v-if="transaction.recurring">
+                      <div class="col col-12"> Repeats: {{ transaction.recurringInterval }} </div>
                     </div>
                   </q-card-item>
                 </q-card>


### PR DESCRIPTION
## Summary
- collapse extra transaction filters on mobile in Vue app
- adjust mobile transaction layout
- collapse extra transaction filters on mobile in Quasar app
- tweak mobile transaction list layout for Quasar

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm run lint` in quasar *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68547dd68b2483299558f2777ddbc723