### PR TITLE
Fix Monthly Overview totals

### DIFF
--- a/quasar/src/pages/ReportsPage.vue
+++ b/quasar/src/pages/ReportsPage.vue
@@ -691,7 +691,11 @@ async function updateReportData() {
     const categoryToGroup = new Map<string, string>();
     budgets.forEach((budget) => {
       budget.categories.forEach((cat) => {
-        if (cat.group && cat.group.toLowerCase() !== "income") {
+        if (
+          cat.group &&
+          cat.group.toLowerCase() !== "income" &&
+          cat.name.toLowerCase() !== "income"
+        ) {
           categoryToGroup.set(cat.name, cat.group);
         }
       });
@@ -713,8 +717,13 @@ async function updateReportData() {
         if (!transaction.deleted) {
           transaction.categories.forEach((cat) => {
             const groupName = categoryToGroup.get(cat.category);
-            if (groupName && groupName.toLowerCase() !== "income") {
-              actualTotal += cat.amount || 0;
+            if (
+              groupName &&
+              groupName.toLowerCase() !== "income" &&
+              cat.category.toLowerCase() !== "income"
+            ) {
+              const sign = transaction.isIncome ? 1 : -1;
+              actualTotal += (cat.amount || 0) * sign;
             }
           });
         }
@@ -741,9 +750,14 @@ async function updateReportData() {
         if (!transaction.deleted) {
           transaction.categories.forEach((cat) => {
             const groupName = categoryToGroup.get(cat.category);
-            if (groupName && groupName.toLowerCase() !== "income") {
+            if (
+              groupName &&
+              groupName.toLowerCase() !== "income" &&
+              cat.category.toLowerCase() !== "income"
+            ) {
+              const sign = transaction.isIncome ? 1 : -1;
               const group = groupMap.get(groupName) || { planned: 0, actual: 0 };
-              group.actual += cat.amount || 0;
+              group.actual += (cat.amount || 0) * sign;
               groupMap.set(groupName, group);
               const arr = groupTransactions.value[groupName] || [];
               arr.push({
@@ -751,7 +765,7 @@ async function updateReportData() {
                 date: transaction.date,
                 merchant: transaction.merchant,
                 category: cat.category,
-                amount: cat.amount,
+                amount: (cat.amount || 0) * sign,
               });
               groupTransactions.value[groupName] = arr;
             }


### PR DESCRIPTION
## Summary
- filter out the Income category when mapping groups
- account for transaction type when totalling so refunds offset expenses

## Testing
- `npm test` within quasar
- `npm run lint` within quasar *(fails: Cannot find package '@eslint/js')*
- `npm test` within app *(fails: Missing script: "test")*
- `npm run lint` within app *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854896597cc832998c7f00e1922b5b5