### PR TITLE
Fix API base URL env usage

### DIFF
--- a/app/src/firebase/auth.ts
+++ b/app/src/firebase/auth.ts
@@ -2,7 +2,8 @@
 import { auth } from "./index";
 import { onAuthStateChanged, User } from "firebase/auth";
 
-const apiBaseUrl = process.env.VITE_API_BASE_URL;
+const apiBaseUrl =
+  import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api';
 
 export async function getIdToken(): Promise<string | null> {
   const user = auth.currentUser;

--- a/quasar/src/firebase/init.ts
+++ b/quasar/src/firebase/init.ts
@@ -3,11 +3,11 @@ import { getAuth, GoogleAuthProvider, onAuthStateChanged, signInWithPopup } from
 import type { User } from 'firebase/auth';
 
 const firebaseConfig = {
-  apiKey: process.env.VITE_FIREBASE_API_KEY ?? "",
-  authDomain: process.env.VITE_FIREBASE_AUTH_DOMAIN ?? "",
-  projectId: process.env.VITE_FIREBASE_PROJECT_ID ?? "",
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY ?? '',
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN ?? '',
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID ?? '',
 };
-const apiBaseUrl = process.env.VITE_API_BASE_URL;
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api';
 
 const firebaseApp = initializeApp(firebaseConfig);
 const auth = getAuth(firebaseApp);


### PR DESCRIPTION
## Summary
- use `import.meta.env` with fallback URL for Firebase auth
- update Quasar Firebase initialization to use `import.meta.env`

## Testing
- `npm test` in `quasar`
- `npm test` in `app` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6854932dc8408329a59e5f4269e8bfbf