### PR TITLE
Fix ImportMeta env typings

### DIFF
--- a/app/src/env.d.ts
+++ b/app/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/quasar/src/env.d.ts
+++ b/quasar/src/env.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 declare namespace NodeJS {
   interface ProcessEnv {
     NODE_ENV: string;


### PR DESCRIPTION
## Summary
- add Vite env typings for the Vue app
- include vite client types in Quasar env declaration

## Testing
- `npm test` (fails: No test specified)
- `npm test` in `quasar` project

------
https://chatgpt.com/codex/tasks/task_b_68549854dda08329820ec6e4c29bd28b