### PR TITLE
Add deleted filter on transactions

### DIFF
--- a/app/src/store/ui.ts
+++ b/app/src/store/ui.ts
@@ -20,6 +20,7 @@ export const useUIStore = defineStore("uiState", () => {
   const entriesFilterDate = ref("");
   const entriesFilterAccount = ref("");
   const entriesFilterDuplicates = ref(false);
+  const entriesFilterDeleted = ref(false);
   const selectedBudgetIds = ref<string[]>([]);
 
   return {
@@ -39,6 +40,7 @@ export const useUIStore = defineStore("uiState", () => {
     entriesFilterDate,
     entriesFilterAccount,
     entriesFilterDuplicates,
+    entriesFilterDeleted,
     selectedBudgetIds,
   };
 });

--- a/app/src/views/TransactionsView.vue
+++ b/app/src/views/TransactionsView.vue
@@ -29,6 +29,7 @@
               <v-col cols="auto">Filters</v-col>
               <v-col>
                 <v-checkbox v-model="entriesFilterDuplicates" label="Look for Duplicates" density="compact" hide-details @update:modelValue="applyFilters" />
+                <v-checkbox v-model="entriesFilterDeleted" label="Show Deleted Only" density="compact" hide-details @update:modelValue="applyFilters" />
               </v-col>
             </v-row>
           </v-card-title>
@@ -373,6 +374,7 @@ const {
   entriesFilterDate,
   entriesFilterAccount,
   entriesFilterDuplicates,
+  entriesFilterDeleted,
   selectedBudgetIds,
 } = storeToRefs(uiStore);
 
@@ -450,7 +452,12 @@ const potentialDuplicateIds = computed(() => {
 });
 
 const expenseTransactions = computed(() => {
-  let temp = transactions.value.filter((t) => !t.deleted);
+  let temp = transactions.value;
+  if (entriesFilterDeleted.value) {
+    temp = temp.filter((t) => t.deleted);
+  } else {
+    temp = temp.filter((t) => !t.deleted);
+  }
 
   temp.sort((a, b) => {
     const dateA = new Date(a.date);
@@ -602,7 +609,6 @@ async function loadTransactions() {
       if (budget) {
         budgetStore.updateBudget(budgetId, budget);
         const budgetTransactions = (budget.transactions || [])
-          .filter((tx) => !tx.deleted)
           .map((tx) => ({
             ...tx,
             budgetId,

--- a/quasar/src/pages/TransactionsPage.vue
+++ b/quasar/src/pages/TransactionsPage.vue
@@ -27,6 +27,7 @@
               <div class="col col-auto">Filters</div>
               <div class="col">
                 <q-checkbox v-model="entriesFilterDuplicates" label="Look for Duplicates" density="compact" hide-details @update:modelValue="applyFilters" />
+                <q-checkbox v-model="entriesFilterDeleted" label="Show Deleted Only" density="compact" hide-details @update:modelValue="applyFilters" />
               </div>
             </div>
           </q-card-section>
@@ -360,6 +361,7 @@ const {
   entriesFilterDate,
   entriesFilterAccount,
   entriesFilterDuplicates,
+  entriesFilterDeleted,
   selectedBudgetIds,
 } = storeToRefs(uiStore);
 
@@ -445,7 +447,12 @@ const potentialDuplicateIds = computed(() => {
 });
 
 const expenseTransactions = computed(() => {
-  let temp = transactions.value.filter((t) => !t.deleted);
+  let temp = transactions.value;
+  if (entriesFilterDeleted.value) {
+    temp = temp.filter((t) => t.deleted);
+  } else {
+    temp = temp.filter((t) => !t.deleted);
+  }
 
   temp.sort((a, b) => {
     const dateA = new Date(a.date);
@@ -597,7 +604,6 @@ async function loadTransactions() {
       if (budget) {
         budgetStore.updateBudget(budgetId, budget);
         const budgetTransactions = (budget.transactions || [])
-          .filter((tx) => !tx.deleted)
           .map((tx) => ({
             ...tx,
             budgetId,

--- a/quasar/src/store/ui.ts
+++ b/quasar/src/store/ui.ts
@@ -20,6 +20,7 @@ export const useUIStore = defineStore("uiState", () => {
   const entriesFilterDate = ref("");
   const entriesFilterAccount = ref("");
   const entriesFilterDuplicates = ref(false);
+  const entriesFilterDeleted = ref(false);
   const selectedBudgetIds = ref<string[]>([]);
 
   return {
@@ -39,6 +40,7 @@ export const useUIStore = defineStore("uiState", () => {
     entriesFilterDate,
     entriesFilterAccount,
     entriesFilterDuplicates,
+    entriesFilterDeleted,
     selectedBudgetIds,
   };
 });


### PR DESCRIPTION
## Summary
- show option to display only deleted transactions
- support deleted filter in state stores
- include deleted entries when loading transactions

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm run lint` in quasar *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6854c84e549c83298a78bb60b12dedf0