### PR TITLE
Fix transaction move between budgets

### DIFF
--- a/app/src/components/TransactionForm.vue
+++ b/app/src/components/TransactionForm.vue
@@ -402,16 +402,20 @@ async function save() {
       const targetBudgetId = currentBudgetMonth === targetBudgetMonth ? props.budgetId : `${props.userId}_${entityId}_${targetBudgetMonth}`;
 
       let moved = false;
-      const targetBudget = budgetStore.getBudget(targetBudgetId);
+      let targetBudget = budgetStore.getBudget(targetBudgetId);
+      if (!targetBudget) {
+        targetBudget = await dataAccess.getBudget(targetBudgetId);
+        if (targetBudget) {
+          budgetStore.updateBudget(targetBudgetId, targetBudget);
+        }
+      }
+
       if (targetBudget) {
         if (currentBudgetMonth !== targetBudgetMonth && locTrnsx.id) {
           await dataAccess.deleteTransaction(budget.value, locTrnsx.id, !isLastMonth.value);
           moved = true;
         }
 
-        if (currentBudgetMonth !== targetBudgetMonth && locTrnsx.id) {
-          await dataAccess.deleteTransaction(budget.value, locTrnsx.id, !isLastMonth.value);
-        }
         const savedTransaction = await dataAccess.saveTransaction(targetBudget, locTrnsx, !isLastMonth.value);
         const index = transactions.value.findIndex((t) => t.id === savedTransaction.id);
         if (moved) {

--- a/quasar/src/components/TransactionForm.vue
+++ b/quasar/src/components/TransactionForm.vue
@@ -401,17 +401,20 @@ async function save() {
       const targetBudgetId = currentBudgetMonth === targetBudgetMonth ? props.budgetId : `${props.userId}_${entityId}_${targetBudgetMonth}`;
 
       let moved = false;
-      if (currentBudgetMonth !== targetBudgetMonth && locTrnsx.id) {
-        await dataAccess.deleteTransaction(budget.value, locTrnsx.id, !isLastMonth.value);
-        moved = true;
+      let targetBudget = budgetStore.getBudget(targetBudgetId);
+      if (!targetBudget) {
+        targetBudget = await dataAccess.getBudget(targetBudgetId);
+        if (targetBudget) {
+          budgetStore.updateBudget(targetBudgetId, targetBudget);
+        }
       }
 
-      if (currentBudgetMonth !== targetBudgetMonth && locTrnsx.id) {
-        await dataAccess.deleteTransaction(budget.value, locTrnsx.id, !isLastMonth.value);
-      }
-
-      const targetBudget = budgetStore.getBudget(targetBudgetId);
       if (targetBudget) {
+        if (currentBudgetMonth !== targetBudgetMonth && locTrnsx.id) {
+          await dataAccess.deleteTransaction(budget.value, locTrnsx.id, !isLastMonth.value);
+          moved = true;
+        }
+
         const savedTransaction = await dataAccess.saveTransaction(targetBudget, locTrnsx, !isLastMonth.value);
         const index = transactions.value.findIndex((t) => t.id === savedTransaction.id);
         if (moved) {


### PR DESCRIPTION
## Summary
- check that the target budget exists before deleting transaction when moving between months

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm test` in quasar *(passes: no tests specified)*
- `npm run lint` in quasar *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6854cc7c80a883299368017c1383e41f