### PR TITLE
Refactor to use Quasar notify/loading

### DIFF
--- a/quasar/src/components/EntityForm.vue
+++ b/quasar/src/components/EntityForm.vue
@@ -167,13 +167,6 @@
       </q-card>
     </q-dialog>
 
-    <!-- Snackbar for User Feedback -->
-    <q-snackbar v-model="snackbar" :color="snackbarColor" timeout="3000">
-      {{ snackbarText }}
-      <template v-slot:actions>
-        <q-btn variant="text" @click="snackbar = false">Close</q-btn>
-      </template>
-    </q-snackbar>
   </q-card>
 </template>
 
@@ -205,9 +198,6 @@ const familyStore = useFamilyStore();
 const budgetStore = useBudgetStore();
 const saving = ref(false);
 const importing = ref(false);
-const snackbar = ref(false);
-const snackbarText = ref("");
-const snackbarColor = ref("info");
 const showImportDialog = ref(false);
 const showCancelDialog = ref(false);
 const isEditing = computed(() => props.entityId !== "");
@@ -419,8 +409,12 @@ function resetForm() {
 }
 
 function showSnackbar(text: string, color: string) {
-  snackbarText.value = text;
-  snackbarColor.value = color;
-  snackbar.value = true;
+  $q.notify({
+    message: text,
+    color,
+    position: 'bottom',
+    timeout: 3000,
+    actions: [{ label: 'Close', color: 'white', handler: () => {} }],
+  });
 }
 </script>

--- a/quasar/src/components/MatchBankTransactionsDialog.vue
+++ b/quasar/src/components/MatchBankTransactionsDialog.vue
@@ -293,13 +293,7 @@
       @cancel="showTransactionDialog = false"
     />
 
-    <!-- Add Snackbar -->
-    <q-snackbar v-model="snackbar" :color="snackbarColor" :timeout="timeout">
-      {{ snackbarText }}
-      <template v-slot:actions>
-        <q-btn variant="text" @click="snackbar = false">Close</q-btn>
-      </template>
-    </q-snackbar>
+    <!-- Snackbar handled via $q.notify -->
   </q-dialog>
 </template>
 
@@ -352,10 +346,7 @@ const smartMatches = ref<
 const remainingImportedTransactions = ref<ImportedTransaction[]>(props.remainingImportedTransactions || []);
 const selectedBankTransaction = ref<ImportedTransaction | null>(props.selectedBankTransaction || null);
 
-// Snackbar state
-const snackbar = ref(false);
-const snackbarText = ref("");
-const snackbarColor = ref("success");
+// Snackbar timeout state for notifications
 const timeout = ref(3000);
 
 // Local state for Smart Matches sorting
@@ -1153,10 +1144,13 @@ function resetState(computeMatches = true) {
 }
 
 function showSnackbar(text: string, color = "success") {
-  snackbarText.value = text;
-  snackbarColor.value = color;
-  timeout.value = 3000;
-  snackbar.value = true;
+  $q.notify({
+    message: text,
+    color,
+    position: 'bottom',
+    timeout: timeout.value,
+    actions: [{ label: 'Close', color: 'white', handler: () => {} }],
+  });
 }
 
 // Helper function to create a budget if it doesn't exist

--- a/quasar/src/components/TransactionForm.vue
+++ b/quasar/src/components/TransactionForm.vue
@@ -165,12 +165,6 @@
   </div>
   <div v-else>Loading...</div>
 
-  <q-snackbar v-model="snackbar" :color="snackbarColor" :timeout="3000">
-    {{ snackbarText }}
-    <template v-slot:actions>
-      <q-btn variant="text" @click="snackbar = false">Close</q-btn>
-    </template>
-  </q-snackbar>
 </template>
 
 <script setup lang="ts">
@@ -204,9 +198,6 @@ const emit = defineEmits<{
   (e: "update-transactions", transactions: Transaction[]): void;
 }>();
 
-const snackbar = ref(false);
-const snackbarText = ref("");
-const snackbarColor = ref("success");
 
 const requiredField = [(value: string | null) => !!value || "This field is required", (value: string | null) => value !== "" || "This field is required"];
 
@@ -469,9 +460,13 @@ async function deleteTransaction() {
 }
 
 function showSnackbar(text: string, color = "success") {
-  snackbarText.value = text;
-  snackbarColor.value = color;
-  snackbar.value = true;
+  $q.notify({
+    message: text,
+    color,
+    position: 'bottom',
+    timeout: 3000,
+    actions: [{ label: 'Close', color: 'white', handler: () => {} }],
+  });
 }
 </script>
 

--- a/quasar/src/components/TransactionRegistry.vue
+++ b/quasar/src/components/TransactionRegistry.vue
@@ -80,10 +80,7 @@
       </q-card-section>
     </q-card>
 
-    <!-- Loading Overlay -->
-    <q-overlay :model-value="loading" class="align-center justify-center" scrim="#00000080">
-      <q-circular-progress indeterminate color="primary" size="50" />
-    </q-overlay>
+    <!-- Loading handled via $q.loading -->
 
     <q-card class="mb-4">
       <q-card-section>Filters</q-card-section>
@@ -479,17 +476,13 @@
       </q-card-actions>
     </q-card>
 
-    <q-snackbar v-model="snackbar" :color="snackbarColor" timeout="3000">
-      {{ snackbarText }}
-      <template v-slot:actions>
-        <q-btn variant="text" @click="snackbar = false">Close</q-btn>
-      </template>
-    </q-snackbar>
+    <!-- Snackbar handled via $q.notify -->
   </q-page>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted, computed } from "vue";
+import { useQuasar } from 'quasar';
 import { storeToRefs } from "pinia";
 import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
@@ -524,6 +517,7 @@ interface DisplayTransaction {
 const budgetStore = useBudgetStore();
 const familyStore = useFamilyStore();
 const statementStore = useStatementStore();
+const $q = useQuasar();
 const familyId = computed(() => familyStore.family?.id || "");
 
 const loading = ref(false);
@@ -552,9 +546,6 @@ const statementOptions = computed(() => [
   })),
 ]);
 const selectedStatementId = ref<string | null>(null);
-const snackbar = ref(false);
-const snackbarText = ref("");
-const snackbarColor = ref("success");
 const showActionDialog = ref(false);
 const transactionToAction = ref<any | null>(null);
 const transactionAction = ref("");
@@ -1770,9 +1761,13 @@ function downloadCsv() {
 }
 
 function showSnackbar(text: string, color = "success") {
-  snackbarText.value = text;
-  snackbarColor.value = color;
-  snackbar.value = true;
+  $q.notify({
+    message: text,
+    color,
+    position: 'bottom',
+    timeout: 3000,
+    actions: [{ label: 'Close', color: 'white', handler: () => {} }],
+  });
 }
 
 function applyFilters() {

--- a/quasar/src/pages/SettingsPage.vue
+++ b/quasar/src/pages/SettingsPage.vue
@@ -199,12 +199,6 @@
       />
     </q-dialog>
 
-    <q-snackbar v-model="snackbar" :color="snackbarColor" timeout="3000">
-      {{ snackbarText }}
-      <template v-slot:actions>
-        <q-btn variant="text" @click="snackbar = false">Close</q-btn>
-      </template>
-    </q-snackbar>
   </q-page>
 </template>
 
@@ -222,9 +216,6 @@ const familyStore = useFamilyStore();
 const inviteEmail = ref("");
 const inviting = ref(false);
 const resending = ref(false);
-const snackbar = ref(false);
-const snackbarText = ref("");
-const snackbarColor = ref("success");
 const userEmail = ref<string | null>(null);
 const emailVerified = ref(false);
 const user = ref(auth.currentUser);
@@ -530,8 +521,12 @@ function formatDate(timestamp: Timestamp | null) {
 }
 
 function showSnackbar(text: string, color = "success") {
-  snackbarText.value = text;
-  snackbarColor.value = color;
-  snackbar.value = true;
+  $q.notify({
+    message: text,
+    color,
+    position: 'bottom',
+    timeout: 3000,
+    actions: [{ label: 'Close', color: 'white', handler: () => {} }],
+  });
 }
 </script>

--- a/quasar/src/pages/SetupWizardPage.vue
+++ b/quasar/src/pages/SetupWizardPage.vue
@@ -141,12 +141,13 @@
       </q-card>
     </q-dialog>
 
-    <q-snackbar v-model="snackbar.show" :color="snackbar.color" timeout="3000" location="top right"></q-snackbar>
+    <!-- Snackbar handled via $q.notify -->
   </q-page>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch, nextTick } from "vue";
+import { useQuasar } from 'quasar';
 import { useRouter } from "vue-router";
 import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
@@ -167,8 +168,8 @@ interface WizardStep {
 
 const router = useRouter();
 const familyStore = useFamilyStore();
+const $q = useQuasar();
 
-const snackbar = ref({ show: false, text: "", color: "success" });
 
 // Messages for consistency
 const messages = {
@@ -548,7 +549,13 @@ async function finishSetup() {
 // Snackbar Helper
 function showSnackbarMessage(keyOrText: string, color: string = "success", ...args: any[]) {
   const text = messages[keyOrText] ? messages[keyOrText](...args) : keyOrText;
-  snackbar.value = { show: true, text, color };
+  $q.notify({
+    message: text,
+    color,
+    position: 'bottom',
+    timeout: 3000,
+    actions: [{ label: 'Close', color: 'white', handler: () => {} }],
+  });
 }
 </script>
 

--- a/quasar/src/pages/TransactionsPage.vue
+++ b/quasar/src/pages/TransactionsPage.vue
@@ -3,10 +3,6 @@
   <q-page :class="isMobile ? 'ps-0' : ''">
     <h1>Transaction and Registry</h1>
 
-    <!-- Loading Overlay -->
-    <q-overlay :model-value="loading" class="align-center justify-center" scrim="#00000080">
-      <q-circular-progress indeterminate color="primary" size="50" />
-    </q-overlay>
 
     <!-- Tabs -->
     <q-tabs v-model="tab" color="primary">
@@ -357,12 +353,6 @@
       @match-transaction="matchTransaction"
     />
 
-    <q-snackbar v-model="snackbar" :color="snackbarColor" timeout="3000">
-      {{ snackbarText }}
-      <template v-slot:actions>
-        <q-btn variant="text" @click="snackbar = false">Close</q-btn>
-      </template>
-    </q-snackbar>
   </q-page>
 </template>
 
@@ -422,9 +412,6 @@ const availableAccounts = ref<Account[]>([]);
 const categoryOptions = ref<string[]>(['Income']);
 const loading = ref(false);
 const editMode = ref(false);
-const snackbar = ref(false);
-const snackbarText = ref('');
-const snackbarColor = ref('success');
 const showTransactionDialog = ref(false);
 const showMatchBudgetTransactionDialog = ref(false);
 const showMatchBankTransactionsDialog = ref(false);
@@ -568,7 +555,14 @@ onMounted(async () => {
     return;
   }
 
-  loading.value = true;
+  $q.loading.show({
+    message: 'Loading data...',
+    spinner: 'QSpinner',
+    spinnerColor: 'primary',
+    spinnerSize: '50px',
+    messageClass: 'q-ml-sm',
+    boxClass: 'flex items-center justify-center',
+  });
   try {
     await familyStore.loadFamily(user.uid);
     await loadBudgets();
@@ -589,7 +583,7 @@ onMounted(async () => {
   } catch (error: any) {
     showSnackbar(`Error loading data: ${error.message}`, 'error');
   } finally {
-    loading.value = false;
+    $q.loading.hide();
   }
 });
 
@@ -611,13 +605,20 @@ async function loadBudgets() {
   const user = auth.currentUser;
   if (!user) return;
 
-  loading.value = true;
+  $q.loading.show({
+    message: 'Loading budgets...',
+    spinner: 'QSpinner',
+    spinnerColor: 'primary',
+    spinnerSize: '50px',
+    messageClass: 'q-ml-sm',
+    boxClass: 'flex items-center justify-center',
+  });
   try {
     await budgetStore.loadBudgets(user.uid, familyStore.selectedEntityId);
   } catch (error: any) {
     showSnackbar(`Error loading budgets: ${error.message}`, 'error');
   } finally {
-    loading.value = false;
+    $q.loading.hide();
   }
 }
 
@@ -628,7 +629,14 @@ async function loadTransactions() {
     return;
   }
 
-  loading.value = true;
+  $q.loading.show({
+    message: 'Loading transactions...',
+    spinner: 'QSpinner',
+    spinnerColor: 'primary',
+    spinnerSize: '50px',
+    messageClass: 'q-ml-sm',
+    boxClass: 'flex items-center justify-center',
+  });
   const allTransactions: Transaction[] = [];
   const allCategories = new Set<string>(['Income']);
 
@@ -653,7 +661,7 @@ async function loadTransactions() {
   } catch (error: any) {
     showSnackbar(`Error loading transactions: ${error.message}`, 'error');
   } finally {
-    loading.value = false;
+    $q.loading.hide();
   }
 }
 
@@ -662,7 +670,14 @@ async function isLastMonth(transaction: Transaction) {
 }
 
 async function saveTransaction(transaction: Transaction) {
-  loading.value = true;
+  $q.loading.show({
+    message: 'Saving transaction...',
+    spinner: 'QSpinner',
+    spinnerColor: 'primary',
+    spinnerSize: '50px',
+    messageClass: 'q-ml-sm',
+    boxClass: 'flex items-center justify-center',
+  });
   try {
     let targetBudgetIdToUse = targetBudgetId.value;
 
@@ -678,7 +693,7 @@ async function saveTransaction(transaction: Transaction) {
   } catch (error: any) {
     showSnackbar(`Error: ${error.message}`, 'error');
   } finally {
-    loading.value = false;
+    $q.loading.hide();
   }
 }
 
@@ -696,6 +711,14 @@ async function deleteTransaction(id: string) {
     return;
   }
 
+  $q.loading.show({
+    message: 'Deleting transaction...',
+    spinner: 'QSpinner',
+    spinnerColor: 'primary',
+    spinnerSize: '50px',
+    messageClass: 'q-ml-sm',
+    boxClass: 'flex items-center justify-center',
+  });
   try {
     const targetTransaction = transactions.value.find((tx) => tx.id === id);
 
@@ -721,6 +744,8 @@ async function deleteTransaction(id: string) {
     await loadTransactions();
   } catch (error: any) {
     showSnackbar(`Error: ${error.message}`, 'error');
+  } finally {
+    $q.loading.hide();
   }
 }
 
@@ -730,6 +755,14 @@ async function restoreTransaction(id: string) {
     return;
   }
 
+  $q.loading.show({
+    message: 'Restoring transaction...',
+    spinner: 'QSpinner',
+    spinnerColor: 'primary',
+    spinnerSize: '50px',
+    messageClass: 'q-ml-sm',
+    boxClass: 'flex items-center justify-center',
+  });
   try {
     const targetTransaction = transactions.value.find((tx) => tx.id === id);
 
@@ -758,6 +791,8 @@ async function restoreTransaction(id: string) {
     await loadTransactions();
   } catch (error: any) {
     showSnackbar(`Error: ${error.message}`, 'error');
+  } finally {
+    $q.loading.hide();
   }
 }
 
@@ -772,7 +807,14 @@ async function matchTransaction(importedTx: ImportedTransaction) {
     return;
   }
 
-  loading.value = true;
+  $q.loading.show({
+    message: 'Matching transaction...',
+    spinner: 'QSpinner',
+    spinnerColor: 'primary',
+    spinnerSize: '50px',
+    messageClass: 'q-ml-sm',
+    boxClass: 'flex items-center justify-center',
+  });
   try {
     const budgetTx = selectedBudgetTransaction.value;
 
@@ -837,7 +879,7 @@ async function matchTransaction(importedTx: ImportedTransaction) {
     console.log(error);
     showSnackbar(`Error matching transaction: ${error.message}`, 'error');
   } finally {
-    loading.value = false;
+    $q.loading.hide();
   }
 }
 
@@ -920,9 +962,13 @@ function formatCategories(categories: { category: string; amount: number }[] | u
 }
 
 function showSnackbar(text: string, color = 'success') {
-  snackbarText.value = text;
-  snackbarColor.value = color;
-  snackbar.value = true;
+  $q.notify({
+    message: text,
+    color,
+    position: 'bottom',
+    timeout: 3000,
+    actions: [{ label: 'Close', color: 'white', handler: () => {} }],
+  });
 }
 
 function updateTransactions(newTransactions: Transaction[]) {


### PR DESCRIPTION
## Summary
- replace `q-overlay` usage with `$q.loading.show/hide`
- switch from `q-snackbar` to `$q.notify`
- update dialogs and forms across the Quasar app

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685703bba6188329a0ea2ad79f07a903