### PR TITLE
Fix snapshot sorting for Timestamp objects

### DIFF
--- a/app/src/dataAccess.ts
+++ b/app/src/dataAccess.ts
@@ -678,7 +678,12 @@ export class DataAccess {
         headers,
       });
       if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      return await response.json();
+      const data = await response.json();
+      return data.map((s: any) => ({
+        ...s,
+        date: new Timestamp(s.date.seconds, s.date.nanoseconds),
+        createdAt: new Timestamp(s.createdAt.seconds, s.createdAt.nanoseconds),
+      }));
     } catch (error) {
       console.error("Error fetching snapshots:", error);
       return [];

--- a/app/src/utils/helpers.ts
+++ b/app/src/utils/helpers.ts
@@ -49,6 +49,19 @@ export function timestampToDate(t: Timestamp): Date {
   return new Date(milliseconds)
 }
 
+export function timestampToMillis(t: any): number {
+  if (!t) return 0;
+  if (t instanceof Timestamp) {
+    return t.toMillis();
+  }
+  if (typeof t === "object" && "seconds" in t) {
+    const seconds = (t as any).seconds ?? 0;
+    const nanos = (t as any).nanoseconds ?? 0;
+    return seconds * 1000 + nanos / 1e6;
+  }
+  return 0;
+}
+
 export function stringToFirestoreTimestamp(dateString: string): Timestamp {
   // Validate the date string format (YYYY-MM-DD)
   const dateRegex = /^\d{4}-\d{2}-\d{2}$/;

--- a/app/src/views/AccountsView.vue
+++ b/app/src/views/AccountsView.vue
@@ -227,7 +227,7 @@ import { useFamilyStore } from "../store/family";
 import AccountList from "../components/AccountList.vue";
 import AccountForm from "../components/AccountForm.vue"; // Import AccountForm directly
 import { Account, Snapshot, ImportedTransaction, Transaction } from "../types";
-import { formatCurrency, formatTimestamp, todayISO } from "../utils/helpers";
+import { formatCurrency, formatTimestamp, todayISO, timestampToMillis } from "../utils/helpers";
 import { v4 as uuidv4 } from "uuid";
 import { Timestamp } from "firebase/firestore";
 
@@ -431,7 +431,9 @@ async function saveAccount(account: Account, isPersonal: boolean) {
 
     if (!editMode.value && snapshot) {
       snapshots.value.push(snapshot);
-      snapshots.value.sort((a, b) => (a && a.date && b && b.date ? b.date.toMillis() - a.date.toMillis() : 1));
+      snapshots.value.sort((a, b) =>
+        a && a.date && b && b.date ? timestampToMillis(b.date) - timestampToMillis(a.date) : 1
+      );
     }
 
     // Handle updates to ImportedTransactions and Budget Transactions if accountNumber or name changed
@@ -578,7 +580,9 @@ async function saveSnapshot() {
 
     await dataAccess.saveSnapshot(familyId.value, snapshot);
     snapshots.value.push(snapshot);
-    snapshots.value.sort((a, b) => (a && a.date && b && b.date ? b.date.toMillis() - a.date.toMillis() : 1));
+    snapshots.value.sort((a, b) =>
+      a && a.date && b && b.date ? timestampToMillis(b.date) - timestampToMillis(a.date) : 1
+    );
 
     showSnackbar("Snapshot saved successfully", "success");
     showSnapshotDialog.value = false;

--- a/quasar/src/dataAccess.ts
+++ b/quasar/src/dataAccess.ts
@@ -689,7 +689,12 @@ export class DataAccess {
         headers,
       });
       if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      return await response.json();
+      const data = await response.json();
+      return data.map((s: any) => ({
+        ...s,
+        date: new Timestamp(s.date.seconds, s.date.nanoseconds),
+        createdAt: new Timestamp(s.createdAt.seconds, s.createdAt.nanoseconds),
+      }));
     } catch (error) {
       console.error('Error fetching snapshots:', error);
       return [];

--- a/quasar/src/pages/AccountsPage.vue
+++ b/quasar/src/pages/AccountsPage.vue
@@ -227,7 +227,7 @@ import { useFamilyStore } from "../store/family";
 import AccountList from "../components/AccountList.vue";
 import AccountForm from "../components/AccountForm.vue"; // Import AccountForm directly
 import { Account, Snapshot, ImportedTransaction, Transaction } from "../types";
-import { formatCurrency, formatTimestamp, todayISO } from "../utils/helpers";
+import { formatCurrency, formatTimestamp, todayISO, timestampToMillis } from "../utils/helpers";
 import { v4 as uuidv4 } from "uuid";
 import { Timestamp } from "firebase/firestore";
 
@@ -431,7 +431,9 @@ async function saveAccount(account: Account, isPersonal: boolean) {
 
     if (!editMode.value && snapshot) {
       snapshots.value.push(snapshot);
-      snapshots.value.sort((a, b) => (a && a.date && b && b.date ? b.date.toMillis() - a.date.toMillis() : 1));
+      snapshots.value.sort((a, b) =>
+        a && a.date && b && b.date ? timestampToMillis(b.date) - timestampToMillis(a.date) : 1
+      );
     }
 
     // Handle updates to ImportedTransactions and Budget Transactions if accountNumber or name changed
@@ -578,7 +580,9 @@ async function saveSnapshot() {
 
     await dataAccess.saveSnapshot(familyId.value, snapshot);
     snapshots.value.push(snapshot);
-    snapshots.value.sort((a, b) => (a && a.date && b && b.date ? b.date.toMillis() - a.date.toMillis() : 1));
+    snapshots.value.sort((a, b) =>
+      a && a.date && b && b.date ? timestampToMillis(b.date) - timestampToMillis(a.date) : 1
+    );
 
     showSnackbar("Snapshot saved successfully", "success");
     showSnapshotDialog.value = false;

--- a/quasar/src/utils/helpers.ts
+++ b/quasar/src/utils/helpers.ts
@@ -49,6 +49,19 @@ export function timestampToDate(t: Timestamp): Date {
   return new Date(milliseconds);
 }
 
+export function timestampToMillis(t: any): number {
+  if (!t) return 0;
+  if (t instanceof Timestamp) {
+    return t.toMillis();
+  }
+  if (typeof t === 'object' && 'seconds' in t) {
+    const seconds = (t as any).seconds ?? 0;
+    const nanos = (t as any).nanoseconds ?? 0;
+    return seconds * 1000 + nanos / 1e6;
+  }
+  return 0;
+}
+
 export function stringToFirestoreTimestamp(dateString: string): Timestamp {
   // Validate the date string format (YYYY-MM-DD)
   const dateRegex = /^\d{4}-\d{2}-\d{2}$/;


### PR DESCRIPTION
## Summary
- convert fetched snapshot dates to `Timestamp` objects
- add `timestampToMillis` helper for cross-format conversions
- sort snapshots using new helper in both Vuetify and Quasar apps

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm run lint` in quasar *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6857075e7f208329b8e26909ac40bd62