### PR TITLE
Fix missing entity dropdown

### DIFF
--- a/app/src/components/EntitySelector.vue
+++ b/app/src/components/EntitySelector.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-menu v-if="showMenu" v-model="menuOpen" offset-y>
+    <v-menu v-model="menuOpen" offset-y>
       <template #activator="{ props }">
         <div v-bind="props" class="entity-selector no-wrap">
           <h4 :class="isMobile ? 'text-secondary' : ''">
@@ -15,9 +15,6 @@
         </v-list-item>
       </v-list>
     </v-menu>
-    <div v-else class="entity-selector no-wrap">
-      <h4>{{ currentEntityName }}</h4>
-    </div>
   </div>
 </template>
 
@@ -43,7 +40,6 @@ const currentEntityName = computed(() => {
   return entities.value.find(e => e.id === familyStore.selectedEntityId)?.name || 'All Entities';
 });
 
-const showMenu = computed(() => entities.value.length > 1);
 
 function selectEntity(id: string) {
   familyStore.selectEntity(id);

--- a/quasar/src/components/EntitySelector.vue
+++ b/quasar/src/components/EntitySelector.vue
@@ -1,27 +1,20 @@
 <template>
   <div>
-    <template v-if="showMenu">
-      <q-menu v-model="menuOpen" offset-y>
-        <template #activator="{ props }">
-          <div v-bind="props" class="entity-selector no-wrap">
-            <h1>
-              {{ currentEntityName }}
-              <q-icon small>expand_more</q-icon>
-            </h1>
-          </div>
-        </template>
-        <q-list class="entity-menu">
-          <q-item v-for="option in entityOptions" :key="option.id" clickable @click="selectEntity(option.id)">
-            <q-item-section>{{ option.name }}</q-item-section>
-          </q-item>
-        </q-list>
-      </q-menu>
-    </template>
-    <template v-else>
-      <div class="entity-selector no-wrap">
-        <h1>{{ currentEntityName }}</h1>
-      </div>
-    </template>
+    <q-menu v-model="menuOpen" offset-y>
+      <template #activator="{ props }">
+        <div v-bind="props" class="entity-selector no-wrap">
+          <h1>
+            {{ currentEntityName }}
+            <q-icon small>expand_more</q-icon>
+          </h1>
+        </div>
+      </template>
+      <q-list class="entity-menu">
+        <q-item v-for="option in entityOptions" :key="option.id" clickable @click="selectEntity(option.id)">
+          <q-item-section>{{ option.name }}</q-item-section>
+        </q-item>
+      </q-list>
+    </q-menu>
   </div>
 </template>
 
@@ -46,7 +39,6 @@ const currentEntityName = computed(() => {
   return entities.value.find(e => e.id === familyStore.selectedEntityId)?.name || 'All Entities';
 });
 
-const showMenu = computed(() => entities.value.length > 1);
 
 function selectEntity(id: string) {
   familyStore.selectEntity(id);


### PR DESCRIPTION
## Summary
- always display the entity dropdown menu

## Testing
- `npm test` (no tests)
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68570b931e3c8329b767311add014753