### PR TITLE
Fix Quasar reports page computed refs

### DIFF
--- a/app/src/views/ReportsView.vue
+++ b/app/src/views/ReportsView.vue
@@ -115,7 +115,7 @@
             <v-card>
               <v-card-text class="text-center">
                 <div style="height: 300px">
-                  <LineChart v-if="monthlyBudgetData?.labels?.length > 0" :data="monthlyBudgetData" :options="monthlyBudgetChartOptions" />
+                    <LineChart v-if="monthlyBudgetData.labels.length > 0" :data="monthlyBudgetData" :options="monthlyBudgetChartOptions" />
                   <p v-else>No budget data available</p>
                 </div>
               </v-card-text>
@@ -163,7 +163,7 @@
               <v-card-text>
                 <div style="height: 400px">
                   <v-progress-circular v-if="isLoadingSnapshots" indeterminate color="primary" />
-                  <LineChart v-else-if="netWorthData?.labels?.length > 0" :data="netWorthData" :options="netWorthChartOptions" />
+                    <LineChart v-else-if="netWorthData.labels.length > 0" :data="netWorthData" :options="netWorthChartOptions" />
                   <p v-else>No net worth data available</p>
                 </div>
               </v-card-text>
@@ -177,7 +177,7 @@
               <v-card-text>
                 <div style="height: 400px">
                   <v-progress-circular v-if="isLoadingSnapshots" indeterminate color="primary" />
-                  <LineChart v-else-if="assetDebtData?.labels?.length > 0" :data="assetDebtData" :options="assetDebtChartOptions" />
+                    <LineChart v-else-if="assetDebtData.labels.length > 0" :data="assetDebtData" :options="assetDebtChartOptions" />
                   <p v-else>No asset/debt data available</p>
                 </div>
               </v-card-text>

--- a/quasar/src/pages/ReportsPage.vue
+++ b/quasar/src/pages/ReportsPage.vue
@@ -141,7 +141,7 @@
             <q-card>
               <q-card-section class="text-center">
                 <div style="height: 300px">
-                  <LineChart v-if="monthlyBudgetData?.labels?.length > 0" :data="monthlyBudgetData" :options="monthlyBudgetChartOptions" />
+                  <LineChart v-if="monthlyBudgetData.labels.length > 0" :data="monthlyBudgetData" :options="monthlyBudgetChartOptions" />
                   <p v-else>No budget data available</p>
                 </div>
               </q-card-section>
@@ -189,7 +189,7 @@
               <q-card-section>
                 <div style="height: 400px">
                   <q-circular-progress v-if="isLoadingSnapshots" indeterminate color="primary" />
-                  <LineChart v-else-if="netWorthData?.labels?.length > 0" :data="netWorthData" :options="netWorthChartOptions" />
+                  <LineChart v-else-if="netWorthData.labels.length > 0" :data="netWorthData" :options="netWorthChartOptions" />
                   <p v-else>No net worth data available</p>
                 </div>
               </q-card-section>
@@ -203,7 +203,7 @@
               <q-card-section>
                 <div style="height: 400px">
                   <q-circular-progress v-if="isLoadingSnapshots" indeterminate color="primary" />
-                  <LineChart v-else-if="assetDebtData?.labels?.length > 0" :data="assetDebtData" :options="assetDebtChartOptions" />
+                  <LineChart v-else-if="assetDebtData.labels.length > 0" :data="assetDebtData" :options="assetDebtChartOptions" />
                   <p v-else>No asset/debt data available</p>
                 </div>
               </q-card-section>


### PR DESCRIPTION
## Summary
- avoid optional chaining on computed data in ReportsPage
- apply same fix to Vuetify version of reports view

## Testing
- `yarn lint` *(fails: quasar@workspace not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_685710e2a0e0832989dac6a1a43ad2ef