### PR TITLE
Fix check for selected budgets

### DIFF
--- a/quasar/src/pages/ReportsPage.vue
+++ b/quasar/src/pages/ReportsPage.vue
@@ -699,7 +699,7 @@ onMounted(async () => {
 });
 
 async function updateReportData() {
-  if (!selectedBudgets.value.length) {
+  if (!selectedBudgets.value || !selectedBudgets.value.length) {
     budgetGroups.value = [];
     groupTransactions.value = {};
     return;


### PR DESCRIPTION
## Summary
- safeguard `updateReportData` when there are no selected budgets

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685713dba4c88329895539d768adb821