### PR TITLE
Sync Quasar dashboard styles with Vuetify

### DIFF
--- a/quasar/quasar.config.ts
+++ b/quasar/quasar.config.ts
@@ -18,7 +18,8 @@ export default defineConfig((/* ctx */) => {
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-file#css
     css: [
-      'app.scss'
+      'app.scss',
+      'budget.scss'
     ],
 
     // https://github.com/quasarframework/quasar/tree/dev/extras

--- a/quasar/src/css/budget.scss
+++ b/quasar/src/css/budget.scss
@@ -1,0 +1,39 @@
+.rounded-3 {
+  border-radius: 3px;
+}
+
+.rounded-5 {
+  border-radius: 5px;
+}
+
+.rounded-10 {
+  border-radius: 10px;
+}
+
+.rounded-15 {
+  border-radius: 15px;
+}
+
+.form-row {
+  border-radius: 5px;
+  background-color: #F7F7F7;
+  padding-left: 12px;
+  padding-right: 12px;
+  margin-bottom: 8px;
+  padding-top: 0px;
+  padding-bottom: 0px;
+}
+
+.form-col-label {
+  padding-top: 20px;
+  padding-bottom: 0px;
+  padding-left: 0px;
+  padding-right: 0px;
+  font-weight: bold;
+}
+
+.form-col {
+  padding-bottom: 0px;
+  padding-left: 0px;
+  padding-right: 0px;
+}


### PR DESCRIPTION
## Summary
- add global Quasar stylesheet `budget.scss` to match Vuetify styles
- register the new stylesheet in `quasar.config.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685764135a0483298d1a7d48ced565b3