### PR TITLE
Fix Quasar component names

### DIFF
--- a/quasar/src/components/AccountForm.vue
+++ b/quasar/src/components/AccountForm.vue
@@ -1,7 +1,7 @@
 <!-- src/components/AccountForm.vue -->
 <template>
   <q-form v-model="validForm" @submit.prevent="save">
-    <q-text-field
+    <q-input
       v-model="localAccount.name"
       label="Account Name"
       variant="outlined"
@@ -9,17 +9,17 @@
       :rules="[(v: string | null) => !!v || 'Account name is required']"
       required
       aria-required="true"
-    ></q-text-field>
-    <q-text-field v-model="localAccount.institution" label="Institution" variant="outlined" density="compact"></q-text-field>
+    ></q-input>
+    <q-input v-model="localAccount.institution" label="Institution" variant="outlined" density="compact"></q-input>
     <q-checkbox v-if="showPersonalOption" v-model="isPersonalAccount" label="Personal Account (not shared with family)" density="compact"></q-checkbox>
-    <q-text-field
+    <q-input
       v-if="localAccount.type === 'Bank' || localAccount.type === 'CreditCard'"
       v-model="localAccount.accountNumber"
       label="Account Number"
       variant="outlined"
       density="compact"
-    ></q-text-field>
-    <q-text-field
+    ></q-input>
+    <q-input
       v-if="localAccount.type === 'Loan' || localAccount.type === 'CreditCard'"
       v-model.number="localAccount.details.interestRate"
       label="Interest Rate (%)"
@@ -27,31 +27,31 @@
       step="0.01"
       variant="outlined"
       density="compact"
-    ></q-text-field>
-    <q-text-field
+    ></q-input>
+    <q-input
       v-if="localAccount.type === AccountType.Property"
       v-model.number="localAccount.details.appraisedValue"
       label="Original Value"
       type="number"
       variant="outlined"
       density="compact"
-    ></q-text-field>
-    <q-text-field
+    ></q-input>
+    <q-input
       v-if="localAccount.type === AccountType.Property"
       v-model="localAccount.details.address"
       :label="localAccount.type === AccountType.Property ? 'Address' : 'Description'"
       variant="outlined"
       density="compact"
-    ></q-text-field>
-    <q-text-field
+    ></q-input>
+    <q-input
       v-if="localAccount.type === AccountType.Investment || localAccount.type === AccountType.Loan"
       v-model="localAccount.details.maturityDate"
       label="Maturity Date"
       type="date"
       variant="outlined"
       density="compact"
-    ></q-text-field>
-    <q-text-field
+    ></q-input>
+    <q-input
       v-model.number="localAccount.balance"
       :label="localAccount.category === 'Liability' ? 'Current Balance (as positive #)' : 'Current Value'"
       type="number"
@@ -59,7 +59,7 @@
       density="compact"
       hint="Enter the current balance or value as of today"
       :rules="[(v: number | null) => v !== null || 'Balance is required']"
-    ></q-text-field>
+    ></q-input>
     <div class="mt-4">
       <q-btn type="submit" color="primary" :loading="saving" :disabled="!validForm"> Save </q-btn>
       <q-btn color="grey" variant="text" @click="cancel" class="ml-2"> Cancel </q-btn>

--- a/quasar/src/components/AccountList.vue
+++ b/quasar/src/components/AccountList.vue
@@ -13,7 +13,7 @@
       </div>
     </q-card-section>
     <q-card-section>
-      <q-data-table
+      <q-table
         v-if="accounts.length > 0"
         :headers="headers"
         :items="accounts"
@@ -47,7 +47,7 @@
               <q-icon name="delete"></q-icon>
           </q-btn>
         </template>
-      </q-data-table>
+      </q-table>
 
     </q-card-section>
   </q-card>

--- a/quasar/src/components/EntityForm.vue
+++ b/quasar/src/components/EntityForm.vue
@@ -7,13 +7,13 @@
         <!-- Entity Details -->
         <div class="row dense">
           <div class="col col-12 col-sm-6">
-            <q-text-field
+            <q-input
               v-model="entityName"
               label="Entity Name"
               required
               density="compact"
               :rules="[(v: string) => !!v || 'Entity Name is required']"
-            ></q-text-field>
+            ></q-input>
           </div>
           <div class="col col-12 col-sm-6">
             <q-select
@@ -26,7 +26,7 @@
             ></q-select>
           </div>
           <div class="col col-12">
-            <q-text-field v-model="entityEmail" label="Owner Email" density="compact" disabled></q-text-field>
+            <q-input v-model="entityEmail" label="Owner Email" density="compact" disabled></q-input>
           </div>
           <div class="col col-12">
             <q-select
@@ -95,10 +95,10 @@
           <q-item v-for="(category, index) in budget.categories" :key="index">
             <div class="row dense">
               <div class="col px-2 col-12 col-sm-3" >
-                <q-text-field v-model="budget.categories[index]!.name" label="Category" required density="compact"></q-text-field>
+                <q-input v-model="budget.categories[index]!.name" label="Category" required density="compact"></q-input>
               </div>
               <div class="col px-2 col-12 col-sm-3" >
-                <q-text-field v-model="budget.categories[index]!.group" label="Group" required density="compact"></q-text-field>
+                <q-input v-model="budget.categories[index]!.group" label="Group" required density="compact"></q-input>
               </div>
               <div class="col px-2 col-12 col-sm-3" >
                 <Currency-Input v-model.number="budget.categories[index]!.target" label="Target" class="text-right" density="compact" required></Currency-Input>
@@ -118,10 +118,10 @@
         <q-form @submit.prevent="addCategory">
           <div class="row dense">
             <div class="col px-2 col-12 col-sm-3" >
-              <q-text-field v-model="newCategory.name" label="Category" required density="compact"></q-text-field>
+              <q-input v-model="newCategory.name" label="Category" required density="compact"></q-input>
             </div>
             <div class="col px-2 col-12 col-sm-3" >
-              <q-text-field v-model="newCategory.group" label="Group (e.g., Utilities)" density="compact"></q-text-field>
+              <q-input v-model="newCategory.group" label="Group (e.g., Utilities)" density="compact"></q-input>
             </div>
             <div class="col px-2 col-12 col-sm-2" >
               <Currency-Input v-model.number="newCategory.target" label="Target" class="text-right" density="compact" required></Currency-Input>

--- a/quasar/src/components/GroupNamingForm.vue
+++ b/quasar/src/components/GroupNamingForm.vue
@@ -4,13 +4,13 @@
       <p>Let’s get started by naming your Family, Group, or Organization. This name will be used when sharing access with other people.</p>
       <br>
       <q-form @submit.prevent="createFamily">
-        <q-text-field
+        <q-input
           v-model="groupName"
           label="Family/Group/Org Name"
           required
           :rules="[(v: string) => !!v || 'Name is required']"
           autofocus
-        ></q-text-field>
+        ></q-input>
         <q-btn type="submit" color="primary" :loading="creating" block>Save</q-btn>
       </q-form>
     </q-card-section>

--- a/quasar/src/components/MatchBankTransactionsDialog.vue
+++ b/quasar/src/components/MatchBankTransactionsDialog.vue
@@ -45,13 +45,13 @@
                     </q-btn>
                   </div>
                   <div class="col col-12 col-md-4">
-                    <q-text-field
+                    <q-input
                       v-model="smartMatchDateRange"
                       label="Match Date Range (days)"
                       type="number"
                       variant="outlined"
                       @input="computeSmartMatchesLocal()"
-                    ></q-text-field>
+                    ></q-input>
                   </div>
                   <div class="col">
                     <q-btn
@@ -65,7 +65,7 @@
                   </div>
                 </div>
 
-                <q-data-table
+                <q-table
                   :headers="smartMatchHeaders"
                   :items="sortedSmartMatches"
                   v-model="selectedSmartMatchIds"
@@ -87,7 +87,7 @@
                         name="warning"
                       ></q-icon>
                   </template>
-                </q-data-table>
+                </q-table>
                 <q-btn color="primary" @click="confirmSmartMatches" :disabled="selectedSmartMatchIds.length === 0 || props.matching" :loading="props.matching">
                   Confirm Selected Matches ({{ selectedSmartMatchIds.length }})
                 </q-btn>
@@ -135,19 +135,19 @@
                 <!-- Search Filters -->
                 <div class="row mt-4" >
                   <div class="col col-12 col-md-4">
-                    <q-text-field v-model="searchAmount" label="Amount" type="number" variant="outlined" readonly></q-text-field>
+                    <q-input v-model="searchAmount" label="Amount" type="number" variant="outlined" readonly></q-input>
                   </div>
                   <div class="col col-12 col-md-4">
-                    <q-text-field v-model="searchMerchant" label="Merchant" variant="outlined" @input="searchBudgetTransactions"></q-text-field>
+                    <q-input v-model="searchMerchant" label="Merchant" variant="outlined" @input="searchBudgetTransactions"></q-input>
                   </div>
                   <div class="col col-12 col-md-4">
-                    <q-text-field
+                    <q-input
                       v-model="searchDateRange"
                       label="Date Range (days)"
                       type="number"
                       variant="outlined"
                       @input="searchBudgetTransactions"
-                    ></q-text-field>
+                    ></q-input>
                   </div>
                 </div>
 
@@ -176,24 +176,24 @@
                       ></q-select>
                     </div>
                     <div class="col col-12 col-md-3">
-                      <q-combobox
+                      <q-select
                         v-model="split.category"
                         :items="props.categoryOptions"
                         label="Category"
                         variant="outlined"
                         density="compact"
                         :rules="[(v: string) => !!v || 'Category is required']"
-                      ></q-combobox>
+                      ></q-select>
                     </div>
                     <div class="col col-12 col-md-2">
-                      <q-text-field
+                      <q-input
                         v-model.number="split.amount"
                         label="Amount"
                         type="number"
                         variant="outlined"
                         density="compact"
                         :rules="[(v: number) => v > 0 || 'Amount must be greater than 0']"
-                      ></q-text-field>
+                      ></q-input>
                     </div>
                     <div class="col col-12 col-md-1">
                       <q-btn color="error" icon="close" @click="removeSplit(index)" variant="plain"></q-btn>
@@ -230,7 +230,7 @@
                   </div>
                 </div>
 
-                <q-data-table
+                <q-table
                   v-if="potentialMatches.length > 0 && !showSplitForm"
                   :headers="budgetTransactionHeaders"
                   :items="sortedPotentialMatches"
@@ -254,7 +254,7 @@
                       Match
                     </q-btn>
                   </template>
-                </q-data-table>
+                </q-table>
                 <div v-else-if="!showSplitForm" class="mt-4">
                   <q-banner type="info" class="mb-4"> No potential matches found. Adjust the search criteria or add a new transaction. </q-banner>
                   <q-btn color="primary" @click="addNewTransaction" :disabled="props.matching"> Add New Transaction </q-btn>

--- a/quasar/src/components/MatchBudgetTransactionDialog.vue
+++ b/quasar/src/components/MatchBudgetTransactionDialog.vue
@@ -34,16 +34,16 @@
             <h3>Select Bank Transaction to Match</h3>
             <div class="row mb-2" >
               <div class="col col-12 col-md-4">
-                <q-text-field v-model="searchAmount" label="Amount" type="number" variant="outlined"></q-text-field>
+                <q-input v-model="searchAmount" label="Amount" type="number" variant="outlined"></q-input>
               </div>
               <div class="col col-12 col-md-4">
-                <q-text-field v-model="searchMerchant" label="Merchant" variant="outlined"></q-text-field>
+                <q-input v-model="searchMerchant" label="Merchant" variant="outlined"></q-input>
               </div>
               <div class="col col-12 col-md-4">
-                <q-text-field v-model="searchDateRange" label="Date Range (days)" type="number" variant="outlined"></q-text-field>
+                <q-input v-model="searchDateRange" label="Date Range (days)" type="number" variant="outlined"></q-input>
               </div>
             </div>
-            <q-data-table
+            <q-table
               :headers="importedTransactionHeaders"
               :items="filteredImportedTransactions"
               :items-per-page="10"
@@ -61,7 +61,7 @@
               <template v-slot:item.accountId="{ item }">
                 {{ getAccountName(item.accountId) }}
               </template>
-            </q-data-table>
+            </q-table>
           </div>
         </div>
       </q-card-section>

--- a/quasar/src/components/TransactionForm.vue
+++ b/quasar/src/components/TransactionForm.vue
@@ -10,7 +10,7 @@
       <div class="row form-row" >
         <div class="col form-col-label" >Date</div>
         <div class="col form-col col-auto" >
-          <q-text-field
+          <q-input
             v-model="locTrnsx.date"
             type="date"
             :rules="requiredField"
@@ -18,13 +18,13 @@
             variant="plain"
             density="compact"
             class="text-right"
-          ></q-text-field>
+          ></q-input>
         </div>
       </div>
       <div class="row form-row" >
         <div class="col form-col-label q-pr-5" >Merchant</div>
         <div class="col form-col col-auto"  style="min-width: 150px">
-          <q-combobox
+          <q-select
             v-model="locTrnsx.merchant"
             :items="merchantNames"
             :rules="requiredField"
@@ -33,7 +33,7 @@
             menu-icon=""
             class="text-right"
             align-end
-          ></q-combobox>
+          ></q-select>
         </div>
       </div>
       <div class="row form-row" >
@@ -50,7 +50,7 @@
                 <q-icon color="error" @click="removeSplit(index)" name="close"></q-icon>
             </div>
             <div class="col">
-              <q-combobox
+              <q-select
                 v-model="split.category"
                 :items="remainingCategories"
                 label="Category"
@@ -59,7 +59,7 @@
                 variant="plain"
                 menu-icon=""
                 required
-              ></q-combobox>
+              ></q-select>
             </div>
             <div class="col form-col" v-if="locTrnsx.categories.length > 1" no-gutters cols="4">
               <Currency-Input v-model="split.amount" class="text-right" variant="plain"></Currency-Input>
@@ -118,37 +118,37 @@
         <div class="row form-row" >
           <div class="col form-col-label" >Posted Date</div>
           <div class="col form-col" >
-            <q-text-field v-model="locTrnsx.postedDate" type="date" variant="plain" density="compact" readonly></q-text-field>
+            <q-input v-model="locTrnsx.postedDate" type="date" variant="plain" density="compact" readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >
           <div class="col form-col-label q-pr-5" >Imported Merchant</div>
           <div class="col form-col"  style="min-width: 150px">
-            <q-text-field v-model="locTrnsx.importedMerchant" variant="plain" density="compact" readonly></q-text-field>
+            <q-input v-model="locTrnsx.importedMerchant" variant="plain" density="compact" readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >
           <div class="col form-col-label" >Account Source</div>
           <div class="col form-col" >
-            <q-text-field v-model="locTrnsx.accountSource" variant="plain" density="compact" readonly></q-text-field>
+            <q-input v-model="locTrnsx.accountSource" variant="plain" density="compact" readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >
           <div class="col form-col-label" >Account Number</div>
           <div class="col form-col" >
-            <q-text-field v-model="locTrnsx.accountNumber" variant="plain" density="compact" readonly></q-text-field>
+            <q-input v-model="locTrnsx.accountNumber" variant="plain" density="compact" readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >
           <div class="col form-col-label" >Check Number</div>
           <div class="col form-col" >
-            <q-text-field v-model="locTrnsx.checkNumber" variant="plain" density="compact" readonly></q-text-field>
+            <q-input v-model="locTrnsx.checkNumber" variant="plain" density="compact" readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >
           <div class="col form-col-label" >Status</div>
           <div class="col form-col" >
-            <q-text-field v-model="locTrnsx.status" variant="plain" density="compact" readonly></q-text-field>
+            <q-input v-model="locTrnsx.status" variant="plain" density="compact" readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >

--- a/quasar/src/components/TransactionRegistry.vue
+++ b/quasar/src/components/TransactionRegistry.vue
@@ -87,7 +87,7 @@
       <q-card-section>
         <div class="row">
           <div class="col col-6 col-md-6">
-            <q-text-field
+            <q-input
               append-inner-icon="search"
               density="compact"
               label="Search"
@@ -95,7 +95,7 @@
               single-line
               v-model="search"
               @input="applyFilters"
-            ></q-text-field>
+            ></q-input>
           </div>
           <div class="col col-auto">
             <q-checkbox v-model="filterMatched" label="Show Only Unmatched" density="compact" @input="applyFilters"></q-checkbox>
@@ -103,18 +103,18 @@
         </div>
         <div class="row">
           <div class="col col-12 col-md-2">
-            <q-text-field v-model="filterMerchant" label="Merchant" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+            <q-input v-model="filterMerchant" label="Merchant" variant="outlined" density="compact" @input="applyFilters"></q-input>
           </div>
           <div class="col col-12 col-md-2">
-            <q-text-field v-model="filterAmount" label="Amount" type="number" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+            <q-input v-model="filterAmount" label="Amount" type="number" variant="outlined" density="compact" @input="applyFilters"></q-input>
           </div>
           <div class="col col-12 col-md-3">
-            <q-text-field v-model="filterImportedMerchant" label="Imported Merchant" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+            <q-input v-model="filterImportedMerchant" label="Imported Merchant" variant="outlined" density="compact" @input="applyFilters"></q-input>
           </div>
           <div class="col col-12 col-md-5">
             <div class="row">
               <div class="col col-12 col-md-6">
-                <q-text-field
+                <q-input
                   v-model="filterStartDate"
                   label="Start Date"
                   type="date"
@@ -122,10 +122,10 @@
                   density="compact"
                   :clearable="true"
                   @input="applyFilters"
-                ></q-text-field>
+                ></q-input>
               </div>
               <div class="col col-12 col-md-6">
-                <q-text-field
+                <q-input
                   v-model="filterEndDate"
                   label="End Date"
                   type="date"
@@ -133,7 +133,7 @@
                   density="compact"
                   :clearable="true"
                   @input="applyFilters"
-                ></q-text-field>
+                ></q-input>
               </div>
             </div>
           </div>
@@ -191,7 +191,7 @@
           Delete {{ selectedRows.length }}
         </q-btn>
       </q-card-section>
-      <q-data-table
+      <q-table
         v-model="selectedRows"
         :headers="headers"
         :items="displayTransactions"
@@ -249,7 +249,7 @@
               <q-icon name="delete_outline"></q-icon>
           </q-btn>
         </template>
-      </q-data-table>
+      </q-table>
     </q-card>
 
     <!-- Action Confirmation Dialog -->
@@ -305,7 +305,7 @@
                   <q-input v-model="entry.merchant" label="Merchant" dense :rules="requiredField" />
                 </q-item-section>
                 <q-item-section>
-                  <q-combobox v-model="entry.category" :items="categoryOptions" label="Category" dense :rules="requiredField" />
+                  <q-select v-model="entry.category" :items="categoryOptions" label="Category" dense :rules="requiredField" />
                 </q-item-section>
               </q-item>
             </q-list>
@@ -329,46 +329,46 @@
           <q-form ref="statementForm">
             <div class="row">
               <div class="col">
-                <q-text-field
+                <q-input
                   v-model="newStatement.startDate"
                   label="Start Date"
                   type="date"
                   variant="outlined"
                   density="compact"
                   :rules="requiredField"
-                ></q-text-field>
+                ></q-input>
               </div>
               <div class="col">
-                <q-text-field
+                <q-input
                   v-model.number="newStatement.startingBalance"
                   label="Starting Balance"
                   type="number"
                   variant="outlined"
                   density="compact"
                   :rules="requiredField"
-                ></q-text-field>
+                ></q-input>
               </div>
             </div>
             <div class="row">
               <div class="col">
-                <q-text-field
+                <q-input
                   v-model="newStatement.endDate"
                   label="End Date"
                   type="date"
                   variant="outlined"
                   density="compact"
                   :rules="requiredField"
-                ></q-text-field>
+                ></q-input>
               </div>
               <div class="col">
-                <q-text-field
+                <q-input
                   v-model.number="newStatement.endingBalance"
                   label="Ending Balance"
                   type="number"
                   variant="outlined"
                   density="compact"
                   :rules="requiredField"
-                ></q-text-field>
+                ></q-input>
               </div>
             </div>
           </q-form>
@@ -418,7 +418,7 @@
             </div>
             <div class="row">
               <div class="col">
-                <q-text-field
+                <q-input
                   v-model.number="adjustmentAmount"
                   label="Adjustment Amount"
                   type="number"
@@ -427,19 +427,19 @@
                   :rules="adjustmentRules"
                   hint="Positive to increase balance, negative to decrease"
                   persistent-hint
-                ></q-text-field>
+                ></q-input>
               </div>
             </div>
             <div class="row">
               <div class="col">
-                <q-text-field
+                <q-input
                   v-model="adjustmentDate"
                   label="Adjustment Date"
                   type="date"
                   variant="outlined"
                   density="compact"
                   :rules="requiredField"
-                ></q-text-field>
+                ></q-input>
               </div>
             </div>
             <q-btn type="submit" color="primary" :loading="saving">Save Adjustment</q-btn>

--- a/quasar/src/pages/AccountsPage.vue
+++ b/quasar/src/pages/AccountsPage.vue
@@ -62,7 +62,7 @@
             <q-btn color="error" class="mb-4" @click="confirmBatchDeleteSnapshots" :disabled="selectedSnapshots.length === 0" :loading="deleting">
               Delete Selected
             </q-btn>
-            <q-data-table :headers="snapshotHeaders" :items="snapshotsWithSelection" class="elevation-1" :items-per-page="10">
+            <q-table :headers="snapshotHeaders" :items="snapshotsWithSelection" class="elevation-1" :items-per-page="10">
               <template v-slot:header.select="{ column }">
                 <q-checkbox v-model="selectAll" @update:modelValue="toggleSelectAll" hide-details density="compact" />
               </template>
@@ -80,7 +80,7 @@
                     <q-icon name="delete_outline"></q-icon>
                 </q-btn>
               </template>
-            </q-data-table>
+            </q-table>
             <div class="mt-4">
               <p>Net worth trend chart coming soon!</p>
             </div>
@@ -111,8 +111,8 @@
         <q-card-section>Capture Net Worth Snapshot</q-card-section>
         <q-card-section>
           <q-form @submit.prevent="saveSnapshot">
-            <q-text-field v-model="newSnapshot.date" label="Snapshot Date" type="date" variant="outlined" density="compact" required></q-text-field>
-            <q-data-table
+            <q-input v-model="newSnapshot.date" label="Snapshot Date" type="date" variant="outlined" density="compact" required></q-input>
+            <q-table
               :headers="[
                 { title: 'Account', value: 'name' },
                 { title: 'Type', value: 'type' },
@@ -129,15 +129,15 @@
                 {{ getAccountType(item.accountId) }}
               </template>
               <template v-slot:item.value="{ item }">
-                <q-text-field
+                <q-input
                   v-model.number="item.value"
                   type="number"
                   variant="outlined"
                   density="compact"
                   :prefix="getAccountCategory(item.accountId) === 'Liability' ? '-' : ''"
-                ></q-text-field>
+                ></q-input>
               </template>
-            </q-data-table>
+            </q-table>
             <q-btn type="submit" color="primary" :loading="saving" class="mt-4"> Save Snapshot </q-btn>
             <q-btn color="grey" variant="text" @click="showSnapshotDialog = false" class="ml-2"> Cancel </q-btn>
           </q-form>

--- a/quasar/src/pages/DataPage.vue
+++ b/quasar/src/pages/DataPage.vue
@@ -98,14 +98,14 @@
                         <!-- Common Fields -->
                         <div class="row" v-for="(field, index) in commonBankTransactionFields" :key="index">
                           <div class="col col-12 col-md-6">
-                            <q-combobox
+                            <q-select
                               v-model="fieldMapping[field.key]"
                               :items="csvHeaders"
                               :label="field.label"
                               variant="outlined"
                               clearable
                               placeholder="Select a column or type a value"
-                            ></q-combobox>
+                            ></q-select>
                           </div>
                         </div>
 
@@ -113,86 +113,86 @@
                         <div v-if="amountFormat === 'separate'">
                           <div class="row">
                             <div class="col col-12 col-md-6">
-                              <q-combobox
+                              <q-select
                                 v-model="fieldMapping.creditAmount"
                                 :items="csvHeaders"
                                 label="Credit Amount"
                                 variant="outlined"
                                 clearable
                                 placeholder="Select a column or type a value"
-                              ></q-combobox>
+                              ></q-select>
                             </div>
                           </div>
                           <div class="row">
                             <div class="col col-12 col-md-6">
-                              <q-combobox
+                              <q-select
                                 v-model="fieldMapping.debitAmount"
                                 :items="csvHeaders"
                                 label="Debit Amount"
                                 variant="outlined"
                                 clearable
                                 placeholder="Select a column or type a value"
-                              ></q-combobox>
+                              ></q-select>
                             </div>
                           </div>
                         </div>
                         <div v-else-if="amountFormat === 'type'">
                           <div class="row">
                             <div class="col col-12 col-md-6">
-                              <q-combobox
+                              <q-select
                                 v-model="fieldMapping.transactionType"
                                 :items="csvHeaders"
                                 label="Transaction Type Column"
                                 variant="outlined"
                                 clearable
                                 placeholder="Select a column or type a value"
-                              ></q-combobox>
+                              ></q-select>
                             </div>
                           </div>
                           <div class="row">
                             <div class="col col-12 col-md-6">
-                              <q-text-field
+                              <q-input
                                 v-model="creditTypeValue"
                                 label="Value for Credit"
                                 variant="outlined"
                                 placeholder="e.g., 'Credit' or 'CR'"
-                              ></q-text-field>
+                              ></q-input>
                             </div>
                           </div>
                           <div class="row">
                             <div class="col col-12 col-md-6">
-                              <q-text-field
+                              <q-input
                                 v-model="debitTypeValue"
                                 label="Value for Debit"
                                 variant="outlined"
                                 placeholder="e.g., 'Debit' or 'DR'"
-                              ></q-text-field>
+                              ></q-input>
                             </div>
                           </div>
                           <div class="row">
                             <div class="col col-12 col-md-6">
-                              <q-combobox
+                              <q-select
                                 v-model="fieldMapping.amount"
                                 :items="csvHeaders"
                                 label="Amount"
                                 variant="outlined"
                                 clearable
                                 placeholder="Select a column or type a value"
-                              ></q-combobox>
+                              ></q-select>
                             </div>
                           </div>
                         </div>
                         <div v-else-if="amountFormat === 'single'">
                           <div class="row">
                             <div class="col col-12 col-md-6">
-                              <q-combobox
+                              <q-select
                                 v-model="fieldMapping.amount"
                                 :items="csvHeaders"
                                 label="Amount (Positive = Credit, Negative = Debit)"
                                 variant="outlined"
                                 clearable
                                 placeholder="Select a column or type a value"
-                              ></q-combobox>
+                              ></q-select>
                             </div>
                           </div>
                         </div>
@@ -241,33 +241,33 @@
                       </q-tabs>
                       <q-tab-panels v-model="previewTab">
                         <q-tab-panel name="entities">
-                          <q-data-table :headers="entityHeaders" :items="previewData.entities" :items-per-page="5" class="mt-4"></q-data-table>
+                          <q-table :headers="entityHeaders" :items="previewData.entities" :items-per-page="5" class="mt-4"></q-table>
                         </q-tab-panel>
                         <q-tab-panel name="categories">
-                          <q-data-table :headers="categoryHeaders" :items="previewData.categories" :items-per-page="5" class="mt-4"></q-data-table>
+                          <q-table :headers="categoryHeaders" :items="previewData.categories" :items-per-page="5" class="mt-4"></q-table>
                         </q-tab-panel>
                         <q-tab-panel name="transactions">
-                          <q-data-table :headers="transactionHeaders" :items="previewData.transactions" :items-per-page="5" class="mt-4">
+                          <q-table :headers="transactionHeaders" :items="previewData.transactions" :items-per-page="5" class="mt-4">
                             <template v-slot:item.categories="{ item }">
                               <span>{{ formatCategories(item.categories) }}</span>
                             </template>
-                          </q-data-table>
+                          </q-table>
                         </q-tab-panel>
                         <q-tab-panel name="bankTransactions">
-                          <q-data-table
+                          <q-table
                             :headers="bankTransactionPreviewHeaders"
                             :items="previewBankTransactions"
                             :items-per-page="5"
                             class="mt-4"
-                          ></q-data-table>
+                          ></q-table>
                         </q-tab-panel>
                         <q-tab-panel name="accountsAndSnapshots">
-                          <q-data-table
+                          <q-table
                             :headers="accountsAndSnapshotsHeaders"
                             :items="previewData.accountsAndSnapshots"
                             :items-per-page="5"
                             class="mt-4"
-                          ></q-data-table>
+                          ></q-table>
                         </q-tab-panel>
                       </q-tab-panels>
                       <q-banner v-if="previewErrors.length > 0" type="error" class="mt-4">

--- a/quasar/src/pages/SettingsPage.vue
+++ b/quasar/src/pages/SettingsPage.vue
@@ -33,7 +33,7 @@
               </q-item>
             </q-list>
             <q-form @submit.prevent="inviteMember">
-              <q-text-field v-model="inviteEmail" label="Invite Email" type="email" required></q-text-field>
+              <q-input v-model="inviteEmail" label="Invite Email" type="email" required></q-input>
               <q-btn type="submit" :loading="inviting">Invite</q-btn>
             </q-form>
           </q-card-section>
@@ -78,7 +78,7 @@
             <q-card>
               <q-card-section>Imported Transaction</q-card-section>
               <q-card-section>
-                <q-data-table :headers="transactionDocHeaders" :items="importedTransactionDocs" :items-per-page="10" class="elevation-1">
+                <q-table :headers="transactionDocHeaders" :items="importedTransactionDocs" :items-per-page="10" class="elevation-1">
                   <template v-slot:item.createdAt="{ item }">
                     {{ getDateRange(item) }}
                   </template>
@@ -97,7 +97,7 @@
                         <q-icon name="delete_outline"></q-icon>
                     </q-btn>
                   </template>
-                </q-data-table>
+                </q-table>
               </q-card-section>
             </q-card>
           </div>
@@ -111,7 +111,7 @@
             <q-card>
               <q-card-section>Monthly Budgets</q-card-section>
               <q-card-section>
-                <q-data-table :headers="budgetHeaders" :items="budgets" :items-per-page="10" class="elevation-1">
+                <q-table :headers="budgetHeaders" :items="budgets" :items-per-page="10" class="elevation-1">
                   <template v-slot:item.entityName="{ item }">
                     {{ getEntityName(item.entityId) }}
                   </template>
@@ -123,7 +123,7 @@
                         <q-icon name="delete_outline"></q-icon>
                     </q-btn>
                   </template>
-                </q-data-table>
+                </q-table>
               </q-card-section>
             </q-card>
           </div>

--- a/quasar/src/pages/TransactionsPage.vue
+++ b/quasar/src/pages/TransactionsPage.vue
@@ -33,7 +33,7 @@
                 <EntitySelector @change="loadBudgets" />
               </div>
               <div class="col col-12 col-md-4">
-                <q-text-field append-inner-icon="search" density="compact" label="Search" variant="outlined" single-line v-model="entriesSearch"></q-text-field>
+                <q-input append-inner-icon="search" density="compact" label="Search" variant="outlined" single-line v-model="entriesSearch"></q-input>
               </div>
               <div class="col col-12 col-md-4">
                 <q-select
@@ -60,23 +60,23 @@
             <template v-if="!isMobile">
               <div class="row">
                 <div class="col col-12 col-md-2">
-                  <q-text-field v-model="entriesFilterMerchant" label="Merchant" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+                  <q-input v-model="entriesFilterMerchant" label="Merchant" variant="outlined" density="compact" @input="applyFilters"></q-input>
                 </div>
                 <div class="col col-12 col-md-2">
-                  <q-text-field
+                  <q-input
                     v-model="entriesFilterAmount"
                     label="Amount"
                     type="number"
                     variant="outlined"
                     density="compact"
                     @input="applyFilters"
-                  ></q-text-field>
+                  ></q-input>
                 </div>
                 <div class="col col-12 col-md-2">
-                  <q-text-field v-model="entriesFilterNote" label="Note/Memo" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+                  <q-input v-model="entriesFilterNote" label="Note/Memo" variant="outlined" density="compact" @input="applyFilters"></q-input>
                 </div>
                 <div class="col col-12 col-md-2">
-                  <q-text-field
+                  <q-input
                     v-model="entriesFilterDate"
                     label="Date"
                     type="date"
@@ -84,10 +84,10 @@
                     density="compact"
                     :clearable="true"
                     @input="applyFilters"
-                  ></q-text-field>
+                  ></q-input>
                 </div>
                 <div class="col col-12 col-md-2">
-                  <q-text-field v-model="entriesFilterStatus" label="Status" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+                  <q-input v-model="entriesFilterStatus" label="Status" variant="outlined" density="compact" @input="applyFilters"></q-input>
                 </div>
                 <div class="col col-12 col-md-2">
                   <q-select
@@ -110,29 +110,29 @@
                   <q-expansion-panel-text>
                     <div class="row">
                       <div class="col col-12 col-md-2">
-                        <q-text-field
+                        <q-input
                           v-model="entriesFilterMerchant"
                           label="Merchant"
                           variant="outlined"
                           density="compact"
                           @input="applyFilters"
-                        ></q-text-field>
+                        ></q-input>
                       </div>
                       <div class="col col-12 col-md-2">
-                        <q-text-field
+                        <q-input
                           v-model="entriesFilterAmount"
                           label="Amount"
                           type="number"
                           variant="outlined"
                           density="compact"
                           @input="applyFilters"
-                        ></q-text-field>
+                        ></q-input>
                       </div>
                       <div class="col col-12 col-md-2">
-                        <q-text-field v-model="entriesFilterNote" label="Note/Memo" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+                        <q-input v-model="entriesFilterNote" label="Note/Memo" variant="outlined" density="compact" @input="applyFilters"></q-input>
                       </div>
                       <div class="col col-12 col-md-2">
-                        <q-text-field
+                        <q-input
                           v-model="entriesFilterDate"
                           label="Date"
                           type="date"
@@ -140,10 +140,10 @@
                           density="compact"
                           :clearable="true"
                           @input="applyFilters"
-                        ></q-text-field>
+                        ></q-input>
                       </div>
                       <div class="col col-12 col-md-2">
-                        <q-text-field v-model="entriesFilterStatus" label="Status" variant="outlined" density="compact" @input="applyFilters"></q-text-field>
+                        <q-input v-model="entriesFilterStatus" label="Status" variant="outlined" density="compact" @input="applyFilters"></q-input>
                       </div>
                       <div class="col col-12 col-md-2">
                         <q-select


### PR DESCRIPTION
## Summary
- replace deprecated q-data-table with q-table
- update q-combobox to q-select
- change q-text-field to q-input

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68586ee3e0e08329ae0f61e7068b19e6