### PR TITLE
fix: correct header slot typing

### DIFF
--- a/quasar/src/env.d.ts
+++ b/quasar/src/env.d.ts
@@ -10,3 +10,13 @@ declare namespace NodeJS {
 
 declare module "papaparse";
 declare module "file-saver";
+
+// Extend Quasar QTable slot typings so that dynamic item and header
+// slots (e.g. `v-slot:item.foo`) are recognised by TypeScript.
+// This mirrors how slots are used throughout the project.
+declare module 'quasar' {
+  interface QTableSlots {
+    [name: `item.${string}`]: (scope: any) => any
+    [name: `header.${string}`]: (scope: any) => any
+  }
+}


### PR DESCRIPTION
## Summary
- adjust dynamic slot augmentation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685879b5457883299c839c04bc93c775