### PR TITLE
Fix Quasar TS errors

### DIFF
--- a/quasar/src/components/AccountList.vue
+++ b/quasar/src/components/AccountList.vue
@@ -21,19 +21,19 @@
         :items-per-page="100"
         :hide-default-footer="true"
       >
-        <template v-slot:item.owner="{ item }">
-          {{ item.userId ? 'Personal' : 'Shared' }}
+        <template v-slot:body-cell-owner="{ row }">
+          {{ row.userId ? 'Personal' : 'Shared' }}
         </template>
-        <template v-slot:item.balance="{ item }">
-          {{ formatCurrency(item.balance || 0) }}
+        <template v-slot:body-cell-balance="{ row }">
+          {{ formatCurrency(row.balance || 0) }}
         </template>
-        <template v-slot:item.actions="{ item }">
+        <template v-slot:body-cell-actions="{ row }">
           <q-btn
             density="compact"
             variant="plain"
             color="primary"
-            @click="$emit('edit', item)"
-            :disabled="item.userId && item.userId !== userId"
+            @click="$emit('edit', row)"
+            :disabled="row.userId && row.userId !== userId"
           >
               <q-icon name="edit"></q-icon>
           </q-btn>
@@ -41,8 +41,8 @@
             density="compact"
             variant="plain"
             color="error"
-            @click="$emit('delete', item.id)"
-            :disabled="item.userId && item.userId !== userId"
+            @click="$emit('delete', row.id)"
+            :disabled="row.userId && row.userId !== userId"
           >
               <q-icon name="delete"></q-icon>
           </q-btn>

--- a/quasar/src/components/EntityForm.vue
+++ b/quasar/src/components/EntityForm.vue
@@ -175,6 +175,7 @@ import { ref, computed, onMounted, watch } from "vue";
 import type { TemplateBudget, BudgetCategory, TaxForm, Entity} from "../types";
 import { EntityType } from "../types";
 import CurrencyInput from "./CurrencyInput.vue";
+import { useQuasar } from 'quasar';
 import { useBudgetStore } from "../store/budget";
 import { useFamilyStore } from "../store/family";
 import { auth } from "../firebase/init";
@@ -196,6 +197,7 @@ const emit = defineEmits<{
 
 const familyStore = useFamilyStore();
 const budgetStore = useBudgetStore();
+const $q = useQuasar();
 const saving = ref(false);
 const importing = ref(false);
 const showImportDialog = ref(false);

--- a/quasar/src/components/MatchBankTransactionsDialog.vue
+++ b/quasar/src/components/MatchBankTransactionsDialog.vue
@@ -75,13 +75,13 @@
                   hide-default-footer
                   items-per-page="50"
                 >
-                  <template v-slot:item.bankAmount="{ item }"> ${{ toDollars(toCents(item.bankAmount)) }} </template>
-                  <template v-slot:item.bankType="{ item }"> {{ item.bankType }} </template>
-                  <template v-slot:item.budgetAmount="{ item }"> ${{ toDollars(toCents(item.budgetTransaction.amount)) }} </template>
-                  <template v-slot:item.budgetType="{ item }"> {{ item.budgetTransaction.isIncome ? "Income" : "Expense" }} </template>
-                  <template v-slot:item.actions="{ item }">
+                  <template v-slot:body-cell-bankAmount="{ row }"> ${{ toDollars(toCents(row.bankAmount)) }} </template>
+                  <template v-slot:body-cell-bankType="{ row }"> {{ row.bankType }} </template>
+                  <template v-slot:body-cell-budgetAmount="{ row }"> ${{ toDollars(toCents(row.budgetTransaction.amount)) }} </template>
+                  <template v-slot:body-cell-budgetType="{ row }"> {{ row.budgetTransaction.isIncome ? "Income" : "Expense" }} </template>
+                  <template v-slot:body-cell-actions="{ row }">
                       <q-icon
-                        v-if="isBudgetTxMatchedMultiple(item.budgetTransaction.id)"
+                        v-if="isBudgetTxMatchedMultiple(row.budgetTransaction.id)"
                         color="warning"
                         title="This budget transaction matches multiple bank transactions"
                         name="warning"
@@ -239,15 +239,15 @@
                   show-select
                   single-select
                 >
-                  <template v-slot:item.amount="{ item }"> ${{ toDollars(toCents(item.amount)) }} </template>
-                  <template v-slot:item.type="{ item }">
-                    {{ item.isIncome ? "Income" : "Expense" }}
+                  <template v-slot:body-cell-amount="{ row }"> ${{ toDollars(toCents(row.amount)) }} </template>
+                  <template v-slot:body-cell-type="{ row }">
+                    {{ row.isIncome ? "Income" : "Expense" }}
                   </template>
-                  <template v-slot:item.actions="{ item }">
+                  <template v-slot:body-cell-actions="{ row }">
                     <q-btn
                       color="primary"
                       small
-                      @click="matchBankTransaction(item)"
+                      @click="matchBankTransaction(row)"
                       :disabled="!selectedBudgetTransactionForMatch.length || props.matching"
                       :loading="props.matching"
                     >
@@ -670,7 +670,7 @@ async function matchBankTransaction(budgetTransaction: Transaction) {
         updatedTransaction.budgetMonth!,
         fam?.id ?? "",
         user.uid,
-        updatedTransaction.entityId
+        updatedTransaction.entityId || ""
       );
     }
 
@@ -845,7 +845,7 @@ async function handleTransactionAdded(savedTransaction: Transaction) {
     const targetBudgetId = `${user.uid}_${savedTransaction.entityId}_${savedTransaction.budgetMonth}`;
     let budget = budgetStore.getBudget(targetBudgetId);
     if (!budget) {
-      budget = await createBudgetForMonth(savedTransaction.budgetMonth!, family.id, user.uid, savedTransaction.entityId);
+      budget = await createBudgetForMonth(savedTransaction.budgetMonth!, family.id, user.uid, savedTransaction.entityId || "");
     }
 
     budgetStore.updateBudget(targetBudgetId, {

--- a/quasar/src/components/MatchBudgetTransactionDialog.vue
+++ b/quasar/src/components/MatchBudgetTransactionDialog.vue
@@ -52,14 +52,14 @@
               single-select
               @click:row="selectImportedTransaction"
             >
-              <template v-slot:item.creditAmount="{ item }">
-                {{ item.creditAmount ? `$${toDollars(toCents(item.creditAmount))}` : "" }}
+              <template v-slot:body-cell-creditAmount="{ row }">
+                {{ row.creditAmount ? `$${toDollars(toCents(row.creditAmount))}` : "" }}
               </template>
-              <template v-slot:item.debitAmount="{ item }">
-                {{ item.debitAmount ? `$${toDollars(toCents(item.debitAmount))}` : "" }}
+              <template v-slot:body-cell-debitAmount="{ row }">
+                {{ row.debitAmount ? `$${toDollars(toCents(row.debitAmount))}` : "" }}
               </template>
-              <template v-slot:item.accountId="{ item }">
-                {{ getAccountName(item.accountId) }}
+              <template v-slot:body-cell-accountId="{ row }">
+                {{ getAccountName(row.accountId) }}
               </template>
             </q-table>
           </div>

--- a/quasar/src/components/TransactionRegistry.vue
+++ b/quasar/src/components/TransactionRegistry.vue
@@ -206,44 +206,44 @@
         height="600"
         :item-class="getRowClass"
       >
-        <template v-slot:item.amount="{ item }">
-          <span :class="item.isIncome ? 'text-success' : 'text-error'">
-            {{ formatCurrency(item.amount) }}
+        <template v-slot:body-cell-amount="{ row }">
+          <span :class="row.isIncome ? 'text-success' : 'text-error'">
+            {{ formatCurrency(row.amount) }}
           </span>
         </template>
-        <template v-slot:item.balance="{ item }">
-          {{ formatCurrency(item.balance) }}
+        <template v-slot:body-cell-balance="{ row }">
+          {{ formatCurrency(row.balance) }}
         </template>
-        <template v-slot:item.entity="{ item }">
-          {{ getEntityName(item.entityId || item.budgetId) }}
+        <template v-slot:body-cell-entity="{ row }">
+          {{ getEntityName(row.entityId || row.budgetId) }}
         </template>
-        <template v-slot:item.actions="{ item }">
+        <template v-slot:body-cell-actions="{ row }">
           <q-btn
-            v-if="item.status === 'C'"
+            v-if="row.status === 'C'"
             density="compact"
             variant="plain"
             color="warning"
-            @click.stop="confirmAction(item, 'Disconnect')"
+            @click.stop="confirmAction(row, 'Disconnect')"
             title="Disconnect Transaction"
           >
               <q-icon name="link_off"></q-icon>
           </q-btn>
           <q-btn
-            v-if="item.status != 'C' && item.id"
+            v-if="row.status != 'C' && row.id"
             density="compact"
             variant="plain"
             color="error"
-            @click.stop="confirmAction(item, 'Ignore')"
+            @click.stop="confirmAction(row, 'Ignore')"
             title="Ignore Imported Transaction"
           >
               <q-icon name="visibility_off"></q-icon>
           </q-btn>
           <q-btn
-            v-if="item.status != 'C' && item.id"
+            v-if="row.status != 'C' && row.id"
             density="compact"
             variant="plain"
             color="error"
-            @click.stop="confirmAction(item, 'Delete')"
+            @click.stop="confirmAction(row, 'Delete')"
             title="Delete Imported Transaction"
           >
               <q-icon name="delete_outline"></q-icon>


### PR DESCRIPTION
## Summary
- use body-cell slots in QTable components
- add useQuasar instance in `EntityForm.vue`
- handle optional entityId when creating budgets

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68587fbf19ec8329a28580643b4fd91f