### PR TITLE
Enable table sorting on settings page

### DIFF
--- a/app/src/views/SettingsView.vue
+++ b/app/src/views/SettingsView.vue
@@ -247,19 +247,19 @@ const associatedBudgets = ref<Budget[]>([]);
 const entities = computed(() => family.value?.entities || []);
 
 const transactionDocHeaders = [
-  { title: "Document ID", value: "id" },
-  { title: "Transaction Count", value: "importedTransactions.length" },
-  { title: "Account Info", value: "account" },
-  { title: "Created At", value: "createdAt" },
-  { title: "Actions", value: "actions" },
+  { title: "Document ID", value: "id", sortable: true },
+  { title: "Transaction Count", value: "importedTransactions.length", sortable: true },
+  { title: "Account Info", value: "account", sortable: true },
+  { title: "Created At", value: "createdAt", sortable: true },
+  { title: "Actions", value: "actions", sortable: false },
 ];
 
 const budgetHeaders = [
-  { title: "Budget ID", value: "budgetId" },
-  { title: "Month", value: "month" },
-  { title: "Entity Name", value: "entityName" },
-  { title: "Transaction Count", value: "transactionCount" },
-  { title: "Actions", value: "actions" },
+  { title: "Budget ID", value: "budgetId", sortable: true },
+  { title: "Month", value: "month", sortable: true },
+  { title: "Entity Name", value: "entityName", sortable: true },
+  { title: "Transaction Count", value: "transactionCount", sortable: true },
+  { title: "Actions", value: "actions", sortable: false },
 ];
 
 onMounted(async () => {

--- a/quasar/src/pages/SettingsPage.vue
+++ b/quasar/src/pages/SettingsPage.vue
@@ -238,19 +238,19 @@ const associatedBudgets = ref<Budget[]>([]);
 const entities = computed(() => family.value?.entities || []);
 
 const transactionDocHeaders = [
-  { title: "Document ID", value: "id" },
-  { title: "Transaction Count", value: "importedTransactions.length" },
-  { title: "Account Info", value: "account" },
-  { title: "Created At", value: "createdAt" },
-  { title: "Actions", value: "actions" },
+  { title: "Document ID", value: "id", sortable: true },
+  { title: "Transaction Count", value: "importedTransactions.length", sortable: true },
+  { title: "Account Info", value: "account", sortable: true },
+  { title: "Created At", value: "createdAt", sortable: true },
+  { title: "Actions", value: "actions", sortable: false },
 ];
 
 const budgetHeaders = [
-  { title: "Budget ID", value: "budgetId" },
-  { title: "Month", value: "month" },
-  { title: "Entity Name", value: "entityName" },
-  { title: "Transaction Count", value: "transactionCount" },
-  { title: "Actions", value: "actions" },
+  { title: "Budget ID", value: "budgetId", sortable: true },
+  { title: "Month", value: "month", sortable: true },
+  { title: "Entity Name", value: "entityName", sortable: true },
+  { title: "Transaction Count", value: "transactionCount", sortable: true },
+  { title: "Actions", value: "actions", sortable: false },
 ];
 
 onMounted(async () => {


### PR DESCRIPTION
## Summary
- allow column sorting on Vuetify settings tables
- allow column sorting on Quasar settings tables

## Testing
- `npm test` in `app` *(fails: missing script)*
- `npm test` in `quasar`

------
https://chatgpt.com/codex/tasks/task_b_685880592fb48329b9073950330a1cd5