### PR TITLE
Improve logging for batch reconcile

### DIFF
--- a/api/Services/BudgetService.cs
+++ b/api/Services/BudgetService.cs
@@ -553,7 +553,12 @@ namespace FamilyBudgetApi.Services
                 foreach (var req in requestBatch)
                 {
                     var budgetTxIndex = budget.Transactions.FindIndex(t => t.Id == req.BudgetTransactionId);
-                    if (budgetTxIndex < 0) throw new Exception($"Budget transaction {req.BudgetTransactionId} not found in budget {budgetId}");
+                    if (budgetTxIndex < 0)
+                    {
+                        var knownIds = string.Join(",", budget.Transactions.Take(5).Select(t => t.Id));
+                        Console.WriteLine($"BatchReconcileTransactions: transaction {req.BudgetTransactionId} not found in budget {budgetId}. Known IDs sample: {knownIds}");
+                        throw new Exception($"Budget transaction {req.BudgetTransactionId} not found in budget {budgetId}");
+                    }
 
                     var budgetTx = budget.Transactions[budgetTxIndex];
 

--- a/app/src/components/MatchBankTransactionsDialog.vue
+++ b/app/src/components/MatchBankTransactionsDialog.vue
@@ -599,6 +599,8 @@ async function confirmSmartMatches() {
       });
     });
 
+    console.log("confirmSmartMatches matchesByBudget", matchesByBudget);
+
     for (const budgetId in matchesByBudget) {
       const budget = budgetStore.getBudget(budgetId);
       if (!budget) throw new Error(`Budget ${budgetId} not found`);
@@ -607,6 +609,8 @@ async function confirmSmartMatches() {
         budgetId,
         reconciliations: matchesByBudget[budgetId],
       };
+
+      console.log("sending reconcile for", budgetId, reconcileData);
 
       await dataAccess.batchReconcileTransactions(budgetId, budget, reconcileData);
       const updatedBudget = await dataAccess.getBudget(budgetId);

--- a/app/src/dataAccess.ts
+++ b/app/src/dataAccess.ts
@@ -609,12 +609,17 @@ export class DataAccess {
     reconcileData: { budgetId: string; reconciliations: Array<{ budgetTransactionId: string; importedTransactionId: string; match: boolean; ignore: boolean }> }
   ): Promise<void> {
     const headers = await this.getAuthHeaders();
+    console.log("batchReconcileTransactions payload", budgetId, reconcileData);
     const response = await fetch(`${this.apiBaseUrl}/budget/${budgetId}/batch-reconcile`, {
       method: "POST",
       headers,
       body: JSON.stringify(reconcileData),
     });
-    if (!response.ok) throw new Error(`Failed to batch reconcile transactions: ${response.statusText}`);
+    if (!response.ok) {
+      const text = await response.text();
+      console.error("batchReconcileTransactions failed", response.status, text);
+      throw new Error(`Failed to batch reconcile transactions: ${response.statusText}`);
+    }
 
     const budgetStore = useBudgetStore();
     budgetStore.updateBudget(budgetId, budget);


### PR DESCRIPTION
## Summary
- add more debug logging when confirming smart matches
- log payload and failures in `dataAccess.batchReconcileTransactions`
- log known transaction IDs when `BatchReconcileTransactions` fails on the API side

## Testing
- `npm test` in `app` *(fails: Missing script)*
- `npm test` in `quasar`

------
https://chatgpt.com/codex/tasks/task_b_6858861caf488329aedc56303363cc9e