### PR TITLE
Ensure console output goes to ILogger

### DIFF
--- a/api/LoggerTextWriter.cs
+++ b/api/LoggerTextWriter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace FamilyBudgetApi
+{
+    // Redirects Console output to ILogger so that existing Console.WriteLine calls
+    // are captured by the configured logging providers (e.g., Google Cloud Logging).
+    public class LoggerTextWriter : TextWriter
+    {
+        private readonly ILogger _logger;
+        private readonly LogLevel _level;
+
+        public LoggerTextWriter(ILogger logger, LogLevel level)
+        {
+            _logger = logger;
+            _level = level;
+        }
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void WriteLine(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return;
+            _logger.Log(_level, value);
+        }
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -9,6 +9,8 @@ using FamilyBudgetApi.Services;
 using System.IO;
 using FamilyBudgetApi.Controllers;
 using FamilyBudgetApi.Converters;
+using Microsoft.Extensions.Logging;
+using FamilyBudgetApi;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -49,9 +51,11 @@ try
             Credential = credential
         }.Build()));
 
-        // Configure Google Cloud Logging
+        // Configure logging providers
         builder.Logging.ClearProviders();
         builder.Logging.AddGoogle(new LoggingServiceOptions { ProjectId = projectId });
+        // Also log to console for local development
+        builder.Logging.AddConsole();
     }
     finally
     {
@@ -136,6 +140,12 @@ builder.Services.AddSwaggerGen(c =>
 
 var app = builder.Build();
 
+// Redirect Console output to ILogger so existing Console.WriteLine statements
+// are captured by the logging infrastructure (e.g., Google Cloud Logging).
+var logger = app.Services.GetRequiredService<ILogger<Program>>();
+Console.SetOut(new LoggerTextWriter(logger, LogLevel.Information));
+Console.SetError(new LoggerTextWriter(logger, LogLevel.Error));
+
 // Middleware pipeline
 app.UseCors("AllowLocalDomain");
 
@@ -152,5 +162,5 @@ app.MapControllers();
 // Cloud Run sets the PORT environment variable; use it if available, otherwise default to 8080
 var port = Environment.GetEnvironmentVariable("PORT") ?? "8080";
 var url = $"http://0.0.0.0:{port}";
-Console.WriteLine($"Starting server on {url}");
+logger.LogInformation("Starting server on {Url}", url);
 app.Run(url);

--- a/api/family-budget-api.csproj
+++ b/api/family-budget-api.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Going.Plaid" Version="6.39.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageReference Include="Google.Cloud.Firestore" Version="3.10.0" />
-    <PackageReference Include="Google.Cloud.Diagnostics.AspNetCore" Version="4.7.0" />
+    <PackageReference Include="Google.Cloud.Diagnostics.AspNetCore" Version="4.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.7.0" />


### PR DESCRIPTION
## Summary
- redirect Console.WriteLine output to ILogger
- send logs to console and Google Cloud
- downgrade Google Cloud Diagnostics package to 4.4.0

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68589af3d6b48329a722373599795d4c