### PR TITLE
Ensure console output goes to ILogger

### DIFF
--- a/api/LoggerTextWriter.cs
+++ b/api/LoggerTextWriter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace FamilyBudgetApi
+{
+    // Redirects Console output to ILogger so that existing Console.WriteLine calls
+    // are captured by the configured logging providers (e.g., Google Cloud Logging).
+    public class LoggerTextWriter : TextWriter
+    {
+        private readonly ILogger _logger;
+        private readonly LogLevel _level;
+
+        public LoggerTextWriter(ILogger logger, LogLevel level)
+        {
+            _logger = logger;
+            _level = level;
+        }
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void WriteLine(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return;
+            _logger.Log(_level, value);
+        }
+    }
+}

--- a/api/family-budget-api.csproj
+++ b/api/family-budget-api.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Going.Plaid" Version="6.39.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
     <PackageReference Include="Google.Cloud.Firestore" Version="3.10.0" />
-    <PackageReference Include="Google.Cloud.Diagnostics.AspNetCore" Version="4.7.0" />
+    <PackageReference Include="Google.Cloud.Diagnostics.AspNetCore" Version="4.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.7.0" />


### PR DESCRIPTION
## Summary
- redirect Console.WriteLine output to ILogger
- send logs to console and Google Cloud
- downgrade Google Cloud Diagnostics package to 4.4.0
- adjust logging options for older package version

## Testing
- `npm test` *(fails: Missing script: "test" and network access blocked)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68589af3d6b48329a722373599795d4c