### PR TITLE
Fix logging provider options

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -54,7 +54,7 @@ try
 
         // Configure logging providers
         builder.Logging.ClearProviders();
-        builder.Logging.AddGoogle(new GoogleLoggerOptions { ProjectId = projectId });
+        builder.Logging.AddGoogle(new LoggingServiceOptions { ProjectId = projectId });
         // Also log to console for local development
         builder.Logging.AddConsole();
     }


### PR DESCRIPTION
## Summary
- fix Program.cs logging configuration for GCP

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6858a5bac0708329a7416fb3125d52fd