### PR TITLE
Fix credential cleanup timing

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -32,6 +32,11 @@ try
     tempCredentialsPath = Path.Combine(Path.GetTempPath(), "firebase-service-account.json");
     File.WriteAllText(tempCredentialsPath, credentialsJson);
     Environment.SetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS", tempCredentialsPath);
+    AppDomain.CurrentDomain.ProcessExit += (_, __) =>
+    {
+        if (File.Exists(tempCredentialsPath))
+            File.Delete(tempCredentialsPath);
+    };
     Console.WriteLine($"Firebase credentials loaded from environment variable and written to {tempCredentialsPath}");
 
     FirebaseApp.Create(new AppOptions()
@@ -59,11 +64,6 @@ catch (Exception ex)
 {
     Console.WriteLine($"Error initializing Firebase: {ex.Message}");
     throw;
-}
-finally
-{
-    if (File.Exists(tempCredentialsPath))
-        File.Delete(tempCredentialsPath);
 }
 
 // Register controllers and JSON converters


### PR DESCRIPTION
## Summary
- ensure the Firebase service account file stays on disk for the lifetime of the process

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68595c6b38088329ae45140dd866461d