### PR TITLE
Use explicit credentials for Google logging

### DIFF
--- a/api/Logging/CustomGoogleLogger.cs
+++ b/api/Logging/CustomGoogleLogger.cs
@@ -1,6 +1,7 @@
 using Google.Api;
 using Google.Cloud.Logging.Type;
 using Google.Cloud.Logging.V2;
+using Google.Apis.Auth.OAuth2;
 using Microsoft.Extensions.Logging;
 using System;
 
@@ -12,11 +13,14 @@ public class CustomGoogleLogger : ILogger
     private readonly string _projectId;
     private readonly string _categoryName;
 
-    public CustomGoogleLogger(string projectId, string categoryName)
+    public CustomGoogleLogger(string projectId, string categoryName, GoogleCredential credential)
     {
         _projectId = projectId;
         _categoryName = categoryName;
-        _client = LoggingServiceV2Client.Create();
+        _client = new LoggingServiceV2ClientBuilder
+        {
+            Credential = credential
+        }.Build();
     }
 
     public IDisposable BeginScope<TState>(TState state) => null;

--- a/api/Logging/CustomGoogleLoggerProvider.cs
+++ b/api/Logging/CustomGoogleLoggerProvider.cs
@@ -1,19 +1,22 @@
 using Microsoft.Extensions.Logging;
+using Google.Apis.Auth.OAuth2;
 
 namespace FamilyBudgetApi.Logging;
 
 public class CustomGoogleLoggerProvider : ILoggerProvider
 {
     private readonly string _projectId;
+    private readonly GoogleCredential _credential;
 
-    public CustomGoogleLoggerProvider(string projectId)
+    public CustomGoogleLoggerProvider(string projectId, GoogleCredential credential)
     {
         _projectId = projectId;
+        _credential = credential;
     }
 
     public ILogger CreateLogger(string categoryName)
     {
-        return new CustomGoogleLogger(_projectId, categoryName);
+        return new CustomGoogleLogger(_projectId, categoryName, _credential);
     }
 
     public void Dispose() { }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -57,7 +57,7 @@ try
 
     // Configure logging
     builder.Logging.ClearProviders();
-    builder.Logging.AddProvider(new CustomGoogleLoggerProvider(projectId));
+    builder.Logging.AddProvider(new CustomGoogleLoggerProvider(projectId, credential));
     builder.Logging.AddConsole();
 }
 catch (Exception ex)


### PR DESCRIPTION
## Summary
- make Google credential available when creating custom loggers
- thread the credential through provider and logger

## Testing
- `dotnet build api/family-budget-api.csproj -nologo` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68596481f09c8329847960b8dc66d80e