### PR TITLE
Fix filters on budgets tab

### DIFF
--- a/app/src/views/TransactionsView.vue
+++ b/app/src/views/TransactionsView.vue
@@ -484,7 +484,26 @@ const potentialDuplicateIds = computed(() => {
   return ids;
 });
 
-const expenseTransactions = computed(() => {
+const expenseTransactions = ref<Transaction[]>([]);
+
+watch(
+  [
+    transactions,
+    entriesFilterMerchant,
+    entriesFilterAmount,
+    entriesFilterNote,
+    entriesFilterStatus,
+    entriesFilterDate,
+    entriesFilterAccount,
+    entriesFilterDuplicates,
+    entriesIncludeDeleted,
+    entriesSearch,
+  ],
+  applyFilters,
+  { immediate: true },
+);
+
+function applyFilters() {
   let temp = transactions.value;
   if (!entriesIncludeDeleted.value) {
     temp = temp.filter((t) => !t.deleted);
@@ -504,7 +523,6 @@ const expenseTransactions = computed(() => {
     );
   }
   if (entriesFilterAmount.value) {
-    const amount = parseFloat(entriesFilterAmount.value);
     temp = temp.filter((t) => t.amount.toString().includes(entriesFilterAmount.value.toString()));
   }
   if (entriesFilterNote.value) {
@@ -546,8 +564,8 @@ const expenseTransactions = computed(() => {
     temp = temp.filter((t) => dupes.has(t.id));
   }
 
-  return temp;
-});
+  expenseTransactions.value = temp;
+}
 
 const unmatchedImportedTransactions = computed(() => {
   return importedTransactions.value.filter((tx) => !tx.matched && !tx.ignored);
@@ -931,9 +949,6 @@ function updateTransactions(newTransactions: Transaction[]) {
   loadTransactions();
 }
 
-function applyFilters() {
-  // Trigger recomputation of expenseTransactions
-}
 </script>
 
 <style scoped>

--- a/q-srfm/src/pages/TransactionsPage.vue
+++ b/q-srfm/src/pages/TransactionsPage.vue
@@ -465,7 +465,26 @@ const potentialDuplicateIds = computed(() => {
   return ids;
 });
 
-const expenseTransactions = computed(() => {
+const expenseTransactions = ref<Transaction[]>([]);
+
+watch(
+  [
+    transactions,
+    entriesFilterMerchant,
+    entriesFilterAmount,
+    entriesFilterNote,
+    entriesFilterStatus,
+    entriesFilterDate,
+    entriesFilterAccount,
+    entriesFilterDuplicates,
+    entriesIncludeDeleted,
+    entriesSearch,
+  ],
+  applyFilters,
+  { immediate: true },
+);
+
+function applyFilters() {
   let temp = transactions.value;
   if (!entriesIncludeDeleted.value) {
     temp = temp.filter((t) => !t.deleted);
@@ -485,7 +504,6 @@ const expenseTransactions = computed(() => {
     );
   }
   if (entriesFilterAmount.value) {
-    const amount = parseFloat(entriesFilterAmount.value);
     temp = temp.filter((t) => t.amount.toString().includes(entriesFilterAmount.value.toString()));
   }
   if (entriesFilterNote.value) {
@@ -527,8 +545,8 @@ const expenseTransactions = computed(() => {
     temp = temp.filter((t) => dupes.has(t.id));
   }
 
-  return temp;
-});
+  expenseTransactions.value = temp;
+}
 
 const unmatchedImportedTransactions = computed(() => {
   return importedTransactions.value.filter((tx) => !tx.matched && !tx.ignored);
@@ -971,9 +989,6 @@ function updateTransactions(newTransactions: Transaction[]) {
   loadTransactions();
 }
 
-function applyFilters() {
-  // Trigger recomputation of expenseTransactions
-}
 </script>
 
 <style scoped>

--- a/quasar/src/pages/TransactionsPage.vue
+++ b/quasar/src/pages/TransactionsPage.vue
@@ -465,7 +465,26 @@ const potentialDuplicateIds = computed(() => {
   return ids;
 });
 
-const expenseTransactions = computed(() => {
+const expenseTransactions = ref<Transaction[]>([]);
+
+watch(
+  [
+    transactions,
+    entriesFilterMerchant,
+    entriesFilterAmount,
+    entriesFilterNote,
+    entriesFilterStatus,
+    entriesFilterDate,
+    entriesFilterAccount,
+    entriesFilterDuplicates,
+    entriesIncludeDeleted,
+    entriesSearch,
+  ],
+  applyFilters,
+  { immediate: true },
+);
+
+function applyFilters() {
   let temp = transactions.value;
   if (!entriesIncludeDeleted.value) {
     temp = temp.filter((t) => !t.deleted);
@@ -485,7 +504,6 @@ const expenseTransactions = computed(() => {
     );
   }
   if (entriesFilterAmount.value) {
-    const amount = parseFloat(entriesFilterAmount.value);
     temp = temp.filter((t) => t.amount.toString().includes(entriesFilterAmount.value.toString()));
   }
   if (entriesFilterNote.value) {
@@ -527,8 +545,8 @@ const expenseTransactions = computed(() => {
     temp = temp.filter((t) => dupes.has(t.id));
   }
 
-  return temp;
-});
+  expenseTransactions.value = temp;
+}
 
 const unmatchedImportedTransactions = computed(() => {
   return importedTransactions.value.filter((tx) => !tx.matched && !tx.ignored);
@@ -971,9 +989,6 @@ function updateTransactions(newTransactions: Transaction[]) {
   loadTransactions();
 }
 
-function applyFilters() {
-  // Trigger recomputation of expenseTransactions
-}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- ensure filters recompute transactions on Budgets tab

## Testing
- `npm test --prefix quasar`
- `npm test --prefix q-srfm`


------
https://chatgpt.com/codex/tasks/task_b_6865623e8dd08329b72399b6d703a6e2