### PR TITLE
Improve transaction sorting cascade

### DIFF
--- a/app/src/components/TransactionRegistry.vue
+++ b/app/src/components/TransactionRegistry.vue
@@ -749,8 +749,12 @@ const displayTransactions = computed((): DisplayTransaction[] => {
   const allTxs = [...matchedTxs, ...baseUnmatchedTxs].sort((a, b) => {
     const dateA = new Date(a.date);
     const dateB = new Date(b.date);
-    if (dateA.getTime() == dateB.getTime()) return b.merchant.localeCompare(a.merchant);
-    return dateA.getTime() - dateB.getTime(); // Newest first
+    if (dateA.getTime() === dateB.getTime()) {
+      const merchantDiff = b.merchant.localeCompare(a.merchant);
+      if (merchantDiff !== 0) return merchantDiff;
+      return b.amount - a.amount;
+    }
+    return dateA.getTime() - dateB.getTime(); // Will be reversed later
   });
 
   // Calculate running balance

--- a/app/src/views/TransactionsView.vue
+++ b/app/src/views/TransactionsView.vue
@@ -512,7 +512,13 @@ function applyFilters() {
   temp.sort((a, b) => {
     const dateA = new Date(a.date);
     const dateB = new Date(b.date);
-    return dateB.getTime() - dateA.getTime();
+    const dateDiff = dateB.getTime() - dateA.getTime();
+    if (dateDiff !== 0) return dateDiff;
+
+    const merchantDiff = a.merchant.localeCompare(b.merchant);
+    if (merchantDiff !== 0) return merchantDiff;
+
+    return a.amount - b.amount;
   });
 
   if (entriesFilterMerchant.value) {


### PR DESCRIPTION
## Summary
- sort transactions consistently by date, merchant then amount in TransactionsView
- use the same cascading sort for the transaction registry

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_b_686565d11d24832998eb6e212f02d4c3