### PR TITLE
Carry over merchants when duplicating budget

### DIFF
--- a/app/src/views/DashboardView.vue
+++ b/app/src/views/DashboardView.vue
@@ -1222,7 +1222,9 @@ async function duplicateCurrentMonth(month: string) {
       return;
     }
 
-    const newBudget = await createBudgetForMonth(month, family.id, family.ownerUid, familyStore.selectedEntityId);
+    let newBudget = await createBudgetForMonth(month, family.id, family.ownerUid, familyStore.selectedEntityId);
+    newBudget.merchants = budget.value.merchants ? [...budget.value.merchants] : [];
+    await dataAccess.saveBudget(newBudget.budgetId, newBudget);
     await budgetStore.loadBudgets(user.uid, familyStore.selectedEntityId);
 
     showSnackbar("Created new month's budget");

--- a/q-srfm/src/pages/DashboardPage.vue
+++ b/q-srfm/src/pages/DashboardPage.vue
@@ -1218,7 +1218,9 @@ async function duplicateCurrentMonth(month: string) {
       return;
     }
 
-    const newBudget = await createBudgetForMonth(month, family.id, family.ownerUid, familyStore.selectedEntityId);
+    let newBudget = await createBudgetForMonth(month, family.id, family.ownerUid, familyStore.selectedEntityId);
+    newBudget.merchants = budget.value.merchants ? [...budget.value.merchants] : [];
+    await dataAccess.saveBudget(newBudget.budgetId, newBudget);
     await budgetStore.loadBudgets(user.uid, familyStore.selectedEntityId);
 
     showSnackbar("Created new month's budget");

--- a/quasar/src/pages/DashboardPage.vue
+++ b/quasar/src/pages/DashboardPage.vue
@@ -1218,7 +1218,9 @@ async function duplicateCurrentMonth(month: string) {
       return;
     }
 
-    const newBudget = await createBudgetForMonth(month, family.id, family.ownerUid, familyStore.selectedEntityId);
+    let newBudget = await createBudgetForMonth(month, family.id, family.ownerUid, familyStore.selectedEntityId);
+    newBudget.merchants = budget.value.merchants ? [...budget.value.merchants] : [];
+    await dataAccess.saveBudget(newBudget.budgetId, newBudget);
     await budgetStore.loadBudgets(user.uid, familyStore.selectedEntityId);
 
     showSnackbar("Created new month's budget");


### PR DESCRIPTION
## Summary
- ensure `duplicateCurrentMonth` copies merchants from the current budget

## Testing
- `dotnet build` *(fails: command not found)*
- `npm test --silent` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_6865fbfaf958832999702dddeac77ab5