### PR TITLE
Add separate validation controls

### DIFF
--- a/q-srfm/src/pages/DataPage.vue
+++ b/q-srfm/src/pages/DataPage.vue
@@ -322,7 +322,6 @@
               <q-card-section>Export Data</q-card-section>
               <q-card-section>
                 <q-btn color="primary" @click="exportDataToCSV" :loading="exporting">Export All Data</q-btn>
-                <q-btn color="secondary" class="q-ml-md" @click="validateData" :loading="validating">Validate Data</q-btn>
               </q-card-section>
             </q-card>
           </div>
@@ -365,9 +364,8 @@ const familyId = ref<string | null>(null);
 const transactions = ref<Transaction[]>([]);
 const loadingData = ref(false);
 const exporting = ref(false);
-const validating = ref(false);
 const importing = ref(false);
-const loading = computed(() => loadingData.value || importing.value || exporting.value || validating.value);
+const loading = computed(() => loadingData.value || importing.value || exporting.value);
 const activeTab = ref<string>("import");
 const availableAccounts = ref<Account[]>([]);
 const selectedAccountId = ref<string>("");
@@ -1945,77 +1943,6 @@ async function exportDataToCSV() {
   }
 }
 
-async function validateData() {
-  $q.loading.show({
-    message: 'Validating data...',
-    spinner: 'QSpinner',
-    spinnerColor: 'primary',
-    spinnerSize: '50px',
-    messageClass: 'q-ml-sm',
-    boxClass: 'flex items-center justify-center',
-  });
-  validating.value = true;
-  try {
-    const user = auth.currentUser;
-    if (!user) {
-      showSnackbar('User not authenticated', 'error');
-      return;
-    }
-
-    const budgetsList = await dataAccess.loadAccessibleBudgets(user.uid);
-    const seenBudgetIds = new Set<string>();
-    const budgetUpdates: { budgetId: string; transaction: Transaction }[] = [];
-
-    budgetsList.forEach((b) => {
-      b.transactions?.forEach((tx) => {
-        if (!tx.id || seenBudgetIds.has(tx.id)) {
-          const newId = uuidv4();
-          budgetUpdates.push({ budgetId: b.budgetId || b.month, transaction: { ...tx, id: newId } });
-          seenBudgetIds.add(newId);
-        } else {
-          seenBudgetIds.add(tx.id);
-        }
-      });
-    });
-
-    if (budgetUpdates.length > 0) {
-      await dataAccess.updateBudgetTransactions(budgetUpdates);
-    }
-
-    const importedDocs = await dataAccess.getImportedTransactionDocs();
-    const seenImportedIds = new Set<string>();
-    const importedUpdates: ImportedTransaction[] = [];
-
-    importedDocs.forEach((doc) => {
-      doc.importedTransactions.forEach((tx) => {
-        if (!tx.id || seenImportedIds.has(tx.id)) {
-          const newId = `${doc.id}-${uuidv4()}`;
-          importedUpdates.push({ ...tx, id: newId });
-          seenImportedIds.add(newId);
-        } else {
-          seenImportedIds.add(tx.id);
-        }
-      });
-    });
-
-    if (importedUpdates.length > 0) {
-      await dataAccess.updateImportedTransactions(importedUpdates);
-    }
-
-    await loadAllData();
-
-    showSnackbar(
-      `Validation complete. Updated ${budgetUpdates.length} budget transactions and ${importedUpdates.length} imported transactions`,
-      'success',
-    );
-  } catch (error: any) {
-    console.error('Error validating data:', error);
-    showSnackbar(`Error validating data: ${error.message}`, 'error');
-  } finally {
-    $q.loading.hide();
-    validating.value = false;
-  }
-}
 
 function showSnackbar(text: string, color = "success") {
   $q.notify({

--- a/q-srfm/src/pages/SettingsPage.vue
+++ b/q-srfm/src/pages/SettingsPage.vue
@@ -98,6 +98,11 @@
                     </q-btn>
                   </template>
                 </q-table>
+                <div class="q-mt-md">
+                  <q-btn color="secondary" @click="validateImportedTransactions" :loading="validatingImports">
+                    Validate Imported Transactions
+                  </q-btn>
+                </div>
               </q-card-section>
             </q-card>
           </div>
@@ -124,6 +129,11 @@
                     </q-btn>
                   </template>
                 </q-table>
+                <div class="q-mt-md">
+                  <q-btn color="secondary" @click="validateBudgetTransactions" :loading="validatingBudgets">
+                    Validate Budget Transactions
+                  </q-btn>
+                </div>
               </q-card-section>
             </q-card>
           </div>
@@ -207,12 +217,15 @@ import { ref, onMounted, onUnmounted, computed } from "vue";
 import { auth } from "../firebase/init";
 import { dataAccess } from "../dataAccess";
 import { Timestamp } from "firebase/firestore";
-import { Family, PendingInvite, Entity, Budget, ImportedTransactionDoc } from "../types";
+import { Family, PendingInvite, Entity, Budget, ImportedTransactionDoc, Transaction, ImportedTransaction } from "../types";
 import { useFamilyStore } from "../store/family";
 import EntityForm from "../components/EntityForm.vue";
 import { timestampToDate } from "../utils/helpers";
+import { useQuasar } from 'quasar';
+import { v4 as uuidv4 } from "uuid";
 
 const familyStore = useFamilyStore();
+const $q = useQuasar();
 const inviteEmail = ref("");
 const inviting = ref(false);
 const resending = ref(false);
@@ -234,6 +247,8 @@ const showDeleteEntityDialog = ref(false);
 const showEntityDialog = ref(false);
 const entityToDelete = ref<Entity | null>(null);
 const associatedBudgets = ref<Budget[]>([]);
+const validatingBudgets = ref(false);
+const validatingImports = ref(false);
 
 const entities = computed(() => family.value?.entities || []);
 
@@ -513,6 +528,98 @@ async function deleteBudget() {
   } finally {
     showDeleteBudgetDialog.value = false;
     budgetToDelete.value = null;
+  }
+}
+
+async function validateBudgetTransactions() {
+  $q.loading.show({
+    message: 'Validating budget transactions...',
+    spinner: 'QSpinner',
+    spinnerColor: 'primary',
+    spinnerSize: '50px',
+    messageClass: 'q-ml-sm',
+    boxClass: 'flex items-center justify-center',
+  });
+  validatingBudgets.value = true;
+  try {
+    const currentUser = auth.currentUser;
+    if (!currentUser) {
+      showSnackbar('User not authenticated', 'error');
+      return;
+    }
+
+    const budgetsList = await dataAccess.loadAccessibleBudgets(currentUser.uid);
+    const seenBudgetIds = new Set<string>();
+    const budgetUpdates: { budgetId: string; transaction: Transaction }[] = [];
+
+    budgetsList.forEach((b) => {
+      b.transactions?.forEach((tx) => {
+        if (!tx.id || seenBudgetIds.has(tx.id)) {
+          const newId = uuidv4();
+          budgetUpdates.push({ budgetId: b.budgetId || b.month, transaction: { ...tx, id: newId } });
+          seenBudgetIds.add(newId);
+        } else {
+          seenBudgetIds.add(tx.id);
+        }
+      });
+    });
+
+    if (budgetUpdates.length > 0) {
+      await dataAccess.updateBudgetTransactions(budgetUpdates);
+    }
+
+    budgets.value = await dataAccess.loadAccessibleBudgets(currentUser.uid);
+
+    showSnackbar(`Validation complete. Updated ${budgetUpdates.length} budget transactions`, 'success');
+  } catch (error: any) {
+    console.error('Error validating budgets:', error);
+    showSnackbar(`Error validating budgets: ${error.message}`, 'error');
+  } finally {
+    $q.loading.hide();
+    validatingBudgets.value = false;
+  }
+}
+
+async function validateImportedTransactions() {
+  $q.loading.show({
+    message: 'Validating imported transactions...',
+    spinner: 'QSpinner',
+    spinnerColor: 'primary',
+    spinnerSize: '50px',
+    messageClass: 'q-ml-sm',
+    boxClass: 'flex items-center justify-center',
+  });
+  validatingImports.value = true;
+  try {
+    const importedDocs = await dataAccess.getImportedTransactionDocs();
+    const seenImportedIds = new Set<string>();
+    const importedUpdates: ImportedTransaction[] = [];
+
+    importedDocs.forEach((doc) => {
+      doc.importedTransactions.forEach((tx) => {
+        if (!tx.id || seenImportedIds.has(tx.id)) {
+          const newId = `${doc.id}-${uuidv4()}`;
+          importedUpdates.push({ ...tx, id: newId });
+          seenImportedIds.add(newId);
+        } else {
+          seenImportedIds.add(tx.id);
+        }
+      });
+    });
+
+    if (importedUpdates.length > 0) {
+      await dataAccess.updateImportedTransactions(importedUpdates);
+    }
+
+    importedTransactionDocs.value = await dataAccess.getImportedTransactionDocs();
+
+    showSnackbar(`Validation complete. Updated ${importedUpdates.length} imported transactions`, 'success');
+  } catch (error: any) {
+    console.error('Error validating imported transactions:', error);
+    showSnackbar(`Error validating imported transactions: ${error.message}`, 'error');
+  } finally {
+    $q.loading.hide();
+    validatingImports.value = false;
   }
 }
 


### PR DESCRIPTION
## Summary
- add individual validation buttons for imported transactions and budgets in SettingsView
- remove Validate Data control from DataPage now that validation is on Settings pages

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in `app` *(fails: Missing script: "test")*
- `npm run lint` in `app` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_b_6865ff9267c88329aea77fedfa5a809c