### PR TITLE
Fix budget transaction validation

### DIFF
--- a/api/Models/Budget.cs
+++ b/api/Models/Budget.cs
@@ -132,6 +132,10 @@ namespace FamilyBudgetApi.Models
     public class TransactionWithBudgetId
     {
         public string BudgetId { get; set; }
+        // Id of the transaction as currently stored in the budget. This allows
+        // updates where the client changes the transaction id to resolve
+        // duplicates.
+        public string? OldId { get; set; }
         public Transaction Transaction { get; set; }
     }
 

--- a/api/Services/BudgetService.cs
+++ b/api/Services/BudgetService.cs
@@ -410,7 +410,10 @@ namespace FamilyBudgetApi.Services
                 foreach (var txWithBudget in group)
                 {
                     var tx = txWithBudget.Transaction;
-                    var index = transactionsList.FindIndex(t => t.Id == tx.Id);
+                    // Use OldId when provided so we can update transactions whose
+                    // id is being changed during validation.
+                    var lookupId = txWithBudget.OldId ?? tx.Id;
+                    var index = transactionsList.FindIndex(t => t.Id == lookupId);
                     if (index >= 0)
                     {
                         transactionsList[index] = tx;

--- a/app/src/dataAccess.ts
+++ b/app/src/dataAccess.ts
@@ -470,7 +470,9 @@ export class DataAccess {
     return budgetTxs;
   }
 
-  async updateBudgetTransactions(transactions: { budgetId: string; transaction: Transaction }[]): Promise<void> {
+  async updateBudgetTransactions(
+    transactions: { budgetId: string; transaction: Transaction; oldId?: string }[]
+  ): Promise<void> {
     console.log(`Updating budget transactions:`, transactions);
     const headers = await this.getAuthHeaders();
     const response = await fetch(`${this.apiBaseUrl}/budget/transactions/batch-update`, {

--- a/app/src/views/SettingsView.vue
+++ b/app/src/views/SettingsView.vue
@@ -549,13 +549,13 @@ async function validateBudgetTransactions() {
 
     const budgetsList = await dataAccess.loadAccessibleBudgets(currentUser.uid);
     const seenBudgetIds = new Set<string>();
-    const budgetUpdates: { budgetId: string; transaction: Transaction }[] = [];
+    const budgetUpdates: { budgetId: string; transaction: Transaction; oldId?: string }[] = [];
 
     budgetsList.forEach((b) => {
       b.transactions?.forEach((tx) => {
         if (!tx.id || seenBudgetIds.has(tx.id)) {
           const newId = uuidv4();
-          budgetUpdates.push({ budgetId: b.budgetId || b.month, transaction: { ...tx, id: newId } });
+          budgetUpdates.push({ budgetId: b.budgetId || b.month, oldId: tx.id, transaction: { ...tx, id: newId } });
           seenBudgetIds.add(newId);
         } else {
           seenBudgetIds.add(tx.id);

--- a/q-srfm/src/dataAccess.ts
+++ b/q-srfm/src/dataAccess.ts
@@ -478,7 +478,9 @@ export class DataAccess {
     return budgetTxs;
   }
 
-  async updateBudgetTransactions(transactions: { budgetId: string; transaction: Transaction }[]): Promise<void> {
+  async updateBudgetTransactions(
+    transactions: { budgetId: string; transaction: Transaction; oldId?: string }[]
+  ): Promise<void> {
     console.log(`Updating budget transactions:`, transactions);
     const headers = await this.getAuthHeaders();
     const response = await fetch(`${this.apiBaseUrl}/budget/transactions/batch-update`, {

--- a/q-srfm/src/pages/SettingsPage.vue
+++ b/q-srfm/src/pages/SettingsPage.vue
@@ -550,13 +550,13 @@ async function validateBudgetTransactions() {
 
     const budgetsList = await dataAccess.loadAccessibleBudgets(currentUser.uid);
     const seenBudgetIds = new Set<string>();
-    const budgetUpdates: { budgetId: string; transaction: Transaction }[] = [];
+    const budgetUpdates: { budgetId: string; transaction: Transaction; oldId?: string }[] = [];
 
     budgetsList.forEach((b) => {
       b.transactions?.forEach((tx) => {
         if (!tx.id || seenBudgetIds.has(tx.id)) {
           const newId = uuidv4();
-          budgetUpdates.push({ budgetId: b.budgetId || b.month, transaction: { ...tx, id: newId } });
+          budgetUpdates.push({ budgetId: b.budgetId || b.month, oldId: tx.id, transaction: { ...tx, id: newId } });
           seenBudgetIds.add(newId);
         } else {
           seenBudgetIds.add(tx.id);

--- a/quasar/src/dataAccess.ts
+++ b/quasar/src/dataAccess.ts
@@ -478,7 +478,9 @@ export class DataAccess {
     return budgetTxs;
   }
 
-  async updateBudgetTransactions(transactions: { budgetId: string; transaction: Transaction }[]): Promise<void> {
+  async updateBudgetTransactions(
+    transactions: { budgetId: string; transaction: Transaction; oldId?: string }[]
+  ): Promise<void> {
     console.log(`Updating budget transactions:`, transactions);
     const headers = await this.getAuthHeaders();
     const response = await fetch(`${this.apiBaseUrl}/budget/transactions/batch-update`, {


### PR DESCRIPTION
## Summary
- handle transactions where ID changes by tracking oldId in TransactionWithBudgetId
- update budget service to use oldId when replacing transactions
- update data access helpers and settings pages to send oldId when resolving duplicate IDs

## Testing
- `npm test` in app *(fails: Missing script "test")*
- `npm test` in q-srfm
- `npm test` in quasar
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866072f636083299ec01e72690c2ec0