### PR TITLE
Enable sorting and add import transaction details

### DIFF
--- a/app/src/views/SettingsView.vue
+++ b/app/src/views/SettingsView.vue
@@ -78,7 +78,13 @@
             <v-card>
               <v-card-title>Imported Transaction</v-card-title>
               <v-card-text>
-              <v-data-table :headers="transactionDocHeaders" :items="importedTransactionDocs" :items-per-page="10" class="elevation-1">
+              <v-data-table
+                :headers="transactionDocHeaders"
+                :items="importedTransactionDocs"
+                :items-per-page="10"
+                class="elevation-1"
+                @click:row="viewTransactionDoc"
+              >
                   <template v-slot:item.createdAt="{ item }">
                     {{ getDateRange(item) }}
                   </template>
@@ -97,7 +103,7 @@
                       <v-icon>mdi-trash-can-outline</v-icon>
                     </v-btn>
                   </template>
-                </v-data-table>
+              </v-data-table>
                 <div class="mt-4">
                   <v-btn color="secondary" @click="validateImportedTransactions" :loading="validatingImports">
                     Validate Imported Transactions
@@ -140,6 +146,30 @@
         </v-row>
       </v-window-item>
     </v-window>
+
+    <!-- Transaction Document Details Dialog -->
+    <v-dialog v-model="showTransactionDocDialog" max-width="1000px" @hide="closeTransactionDocDialog">
+      <v-card style="min-width: 600px">
+        <v-card-title class="bg-primary py-3">
+          <span class="text-white">Imported Transactions</span>
+        </v-card-title>
+        <v-card-text>
+          <v-data-table
+            :headers="importedTransactionHeaders"
+            :items="selectedTransactionDoc?.importedTransactions || []"
+            :items-per-page="10"
+            class="elevation-1"
+          >
+            <template v-slot:item.accountId="{ item }">
+              {{ item.accountId }}
+            </template>
+          </v-data-table>
+        </v-card-text>
+        <v-card-actions class="justify-end">
+          <v-btn variant="text" color="primary" @click="closeTransactionDocDialog">Close</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
 
     <!-- Delete Transaction Doc Confirmation Dialog -->
     <v-dialog v-model="showDeleteDialog" max-width="400" @keyup.enter="deleteTransactionDoc">
@@ -256,6 +286,8 @@ const entityToDelete = ref<Entity | null>(null);
 const associatedBudgets = ref<Budget[]>([]);
 const validatingBudgets = ref(false);
 const validatingImports = ref(false);
+const showTransactionDocDialog = ref(false);
+const selectedTransactionDoc = ref<ImportedTransactionDoc | null>(null);
 
 const entities = computed(() => family.value?.entities || []);
 
@@ -265,6 +297,17 @@ const transactionDocHeaders = [
   { title: "Account Info", value: "account", sortable: true },
   { title: "Created At", value: "createdAt", sortable: true },
   { title: "Actions", value: "actions", sortable: false },
+];
+
+const importedTransactionHeaders = [
+  { title: 'Posted Date', value: 'postedDate' },
+  { title: 'Payee', value: 'payee' },
+  { title: 'Credit Amount', value: 'creditAmount' },
+  { title: 'Debit Amount', value: 'debitAmount' },
+  { title: 'Account', value: 'accountId' },
+  { title: 'Account Source', value: 'accountSource' },
+  { title: 'Account #', value: 'accountNumber' },
+  { title: 'Check Number', value: 'checkNumber' }
 ];
 
 const budgetHeaders = [
@@ -486,6 +529,16 @@ async function deleteEntity() {
 function confirmDeleteTransactionDoc(doc: ImportedTransactionDoc) {
   transactionDocToDelete.value = doc;
   showDeleteDialog.value = true;
+}
+
+function viewTransactionDoc(event: any, data: any) {
+  selectedTransactionDoc.value = data.item;
+  showTransactionDocDialog.value = true;
+}
+
+function closeTransactionDocDialog() {
+  showTransactionDocDialog.value = false;
+  selectedTransactionDoc.value = null;
 }
 
 async function deleteTransactionDoc() {

--- a/quasar/src/pages/SettingsPage.vue
+++ b/quasar/src/pages/SettingsPage.vue
@@ -78,7 +78,14 @@
             <q-card>
               <q-card-section>Imported Transaction</q-card-section>
               <q-card-section>
-                <q-table :headers="transactionDocHeaders" :rows="importedTransactionDocs" :items-per-page="10" class="elevation-1">
+                <q-table
+                  :columns="transactionDocColumns"
+                  :rows="importedTransactionDocs"
+                  row-key="id"
+                  :items-per-page="10"
+                  class="elevation-1"
+                  @click:row="viewTransactionDoc"
+                >
                   <template v-slot:item.createdAt="{ item }">
                     {{ getDateRange(item) }}
                   </template>
@@ -130,6 +137,30 @@
         </div>
       </q-tab-panel>
     </q-tab-panels>
+
+    <!-- Transaction Document Details Dialog -->
+    <q-dialog v-model="showTransactionDocDialog" max-width="1000px" @hide="closeTransactionDocDialog">
+      <q-card style="min-width: 600px">
+        <q-card-section class="bg-primary py-3">
+          <span class="text-white">Imported Transactions</span>
+        </q-card-section>
+        <q-card-section>
+          <q-table
+            :headers="importedTransactionHeaders"
+            :rows="selectedTransactionDoc?.importedTransactions || []"
+            :items-per-page="10"
+            class="elevation-1"
+          >
+            <template v-slot:item.accountId="{ item }">
+              {{ item.accountId }}
+            </template>
+          </q-table>
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn flat label="Close" color="primary" @click="closeTransactionDocDialog" />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
 
     <!-- Delete Transaction Doc Confirmation Dialog -->
     <q-dialog v-model="showDeleteDialog" max-width="400" @keyup.enter="deleteTransactionDoc">
@@ -235,15 +266,48 @@ const showEntityDialog = ref(false);
 const entityToDelete = ref<Entity | null>(null);
 const associatedBudgets = ref<Budget[]>([]);
 
+const showTransactionDocDialog = ref(false);
+const selectedTransactionDoc = ref<ImportedTransactionDoc | null>(null);
+
 const entities = computed(() => family.value?.entities || []);
 
-const transactionDocHeaders = [
-  { title: "Document ID", value: "id", sortable: true },
-  { title: "Transaction Count", value: "importedTransactions.length", sortable: true },
-  { title: "Account Info", value: "account", sortable: true },
-  { title: "Created At", value: "createdAt", sortable: true },
-  { title: "Actions", value: "actions", sortable: false },
+const transactionDocColumns = [
+  { name: 'id', label: 'Document ID', field: 'id', sortable: true, align: 'left' },
+  {
+    name: 'transactionCount',
+    label: 'Transaction Count',
+    field: (row: ImportedTransactionDoc) => row.importedTransactions.length,
+    sortable: true,
+    align: 'left'
+  },
+  {
+    name: 'account',
+    label: 'Account Info',
+    field: (row: ImportedTransactionDoc) => getAccountInfo(row),
+    sortable: true,
+    align: 'left'
+  },
+  {
+    name: 'createdAt',
+    label: 'Created At',
+    field: (row: ImportedTransactionDoc) => getDateRange(row),
+    sortable: true,
+    align: 'left'
+  },
+  { name: 'actions', label: 'Actions', field: 'actions', sortable: false, align: 'right' }
 ];
+
+const importedTransactionHeaders = [
+  { title: 'Posted Date', value: 'postedDate' },
+  { title: 'Payee', value: 'payee' },
+  { title: 'Credit Amount', value: 'creditAmount' },
+  { title: 'Debit Amount', value: 'debitAmount' },
+  { title: 'Account', value: 'accountId' },
+  { title: 'Account Source', value: 'accountSource' },
+  { title: 'Account #', value: 'accountNumber' },
+  { title: 'Check Number', value: 'checkNumber' }
+];
+
 
 const budgetHeaders = [
   { title: "Budget ID", value: "budgetId", sortable: true },
@@ -464,6 +528,16 @@ async function deleteEntity() {
 function confirmDeleteTransactionDoc(doc: ImportedTransactionDoc) {
   transactionDocToDelete.value = doc;
   showDeleteDialog.value = true;
+}
+
+function viewTransactionDoc(event: any, data: any) {
+  selectedTransactionDoc.value = data.item;
+  showTransactionDocDialog.value = true;
+}
+
+function closeTransactionDocDialog() {
+  showTransactionDocDialog.value = false;
+  selectedTransactionDoc.value = null;
 }
 
 async function deleteTransactionDoc() {


### PR DESCRIPTION
## Summary
- allow sorting and row click on imported transactions table
- view imported transactions for an import in a new dialog
- wire up dialog state and actions in both Settings pages

## Testing
- `npm run lint` *(fails: `@eslint/js` module not found)*
- `npm run lint` in `app` *(fails: `vue-cli-service` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687a38f757d88329bdad80c579cc1fe6