### PR TITLE
Add sync button in SettingsView to sync Firestore to Supabase

### DIFF
--- a/app/src/dataAccess.ts
+++ b/app/src/dataAccess.ts
@@ -828,6 +828,15 @@ export class DataAccess {
     });
     if (!response.ok) throw new Error(`Failed to remove entity member: ${response.statusText}`);
   }
+
+  async syncFirestoreToSupabase(): Promise<void> {
+    const headers = await this.getAuthHeaders();
+    const response = await fetch(`${this.apiBaseUrl}/sync/full`, {
+      method: "POST",
+      headers,
+    });
+    if (!response.ok) throw new Error(`Failed to sync data: ${response.statusText}`);
+  }
 }
 
 export const dataAccess = new DataAccess();

--- a/app/src/views/SettingsView.vue
+++ b/app/src/views/SettingsView.vue
@@ -36,6 +36,11 @@
               <v-text-field v-model="inviteEmail" label="Invite Email" type="email" required></v-text-field>
               <v-btn type="submit" :loading="inviting">Invite</v-btn>
             </v-form>
+            <div class="mt-4">
+              <v-btn color="secondary" @click="syncFirestoreToSupabase" :loading="syncing">
+                Sync Firestore to Supabase
+              </v-btn>
+            </div>
           </v-card-text>
         </v-card>
       </v-window-item>
@@ -263,6 +268,7 @@ const familyStore = useFamilyStore();
 const inviteEmail = ref("");
 const inviting = ref(false);
 const resending = ref(false);
+const syncing = ref(false);
 const snackbar = ref(false);
 const snackbarText = ref("");
 const snackbarColor = ref("success");
@@ -662,6 +668,23 @@ async function validateImportedTransactions() {
     showSnackbar(`Error validating imported transactions: ${error.message}`, 'error');
   } finally {
     validatingImports.value = false;
+  }
+}
+
+async function syncFirestoreToSupabase() {
+  const user = auth.currentUser;
+  if (!user) {
+    showSnackbar('User not authenticated', 'error');
+    return;
+  }
+  syncing.value = true;
+  try {
+    await dataAccess.syncFirestoreToSupabase();
+    showSnackbar('Sync completed successfully', 'success');
+  } catch (error: any) {
+    showSnackbar(`Error syncing data: ${error.message}`, 'error');
+  } finally {
+    syncing.value = false;
   }
 }
 


### PR DESCRIPTION
## Summary
- add `syncFirestoreToSupabase` API helper
- add Sync Firestore button in settings and hook up sync logic

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing error about project configuration)*
- `npx eslint src/dataAccess.ts src/views/SettingsView.vue`


------
https://chatgpt.com/codex/tasks/task_b_68aa0f30add08329a8ffb9ac521987b2