### PR TITLE
Handle snapshot date strings in frontend

### DIFF
--- a/app/src/dataAccess.ts
+++ b/app/src/dataAccess.ts
@@ -675,8 +675,14 @@ export class DataAccess {
       const data = await response.json();
       return data.map((s: any) => ({
         ...s,
-        date: new Timestamp(s.date.seconds, s.date.nanoseconds),
-        createdAt: new Timestamp(s.createdAt.seconds, s.createdAt.nanoseconds),
+        date:
+          typeof s.date === "string"
+            ? Timestamp.fromDate(new Date(s.date))
+            : new Timestamp(s.date.seconds, s.date.nanoseconds),
+        createdAt:
+          typeof s.createdAt === "string"
+            ? Timestamp.fromDate(new Date(s.createdAt))
+            : new Timestamp(s.createdAt.seconds, s.createdAt.nanoseconds),
       }));
     } catch (error) {
       console.error("Error fetching snapshots:", error);

--- a/app/src/views/ReportsView.vue
+++ b/app/src/views/ReportsView.vue
@@ -199,9 +199,8 @@ import { Doughnut, Line } from "vue-chartjs";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, LineElement, PointElement, LinearScale, TimeScale, Filler } from "chart.js";
 import { useBudgetStore } from "../store/budget";
 import { useUIStore } from "../store/ui";
-import { Timestamp } from "firebase/firestore";
 import "chartjs-adapter-date-fns";
-import { timestampToDate, currentMonthISO } from "../utils/helpers";
+import { timestampToDate, currentMonthISO, timestampToMillis } from "../utils/helpers";
 
 // Register Chart.js components
 ChartJS.register(ArcElement, Tooltip, Legend, LineElement, PointElement, LinearScale, TimeScale, Filler);
@@ -307,7 +306,7 @@ function linearRegression(dates: Date[], values: number[]): { slope: number; int
 const netWorthData = computed(() => {
   try {
     if (!snapshots.value || !snapshots.value.length) return { labels: [], datasets: [] };
-    const sortedSnapshots = [...snapshots.value].sort((a, b) => a.date.seconds - b.date.seconds);
+    const sortedSnapshots = [...snapshots.value].sort((a, b) => timestampToMillis(a.date) - timestampToMillis(b.date));
     const dates = sortedSnapshots.map((s) => {
       if (s && s.date) return timestampToDate(s.date);
       return new Date();
@@ -408,7 +407,7 @@ const netWorthChartOptions = ref({
 const assetDebtData = computed(() => {
   try {
     if (!snapshots.value || !snapshots.value.length) return { labels: [], datasets: [] };
-    const sortedSnapshots = [...snapshots.value].sort((a, b) => a.date.seconds - b.date.seconds);
+    const sortedSnapshots = [...snapshots.value].sort((a, b) => timestampToMillis(a.date) - timestampToMillis(b.date));
     const dates = sortedSnapshots.map((s) => {
       if (s && s.date) return timestampToDate(s.date);
       return new Date();


### PR DESCRIPTION
## Summary
- Normalize snapshot `date` and `createdAt` fields to Firestore `Timestamp` whether API returns timestamp objects or ISO strings.
- Extend helper utilities to format and convert both timestamp objects and ISO date strings.
- Sort snapshot data in reports using `timestampToMillis` for compatibility with either format.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing error: ESLint was configured to run on <tsconfigRootDir>/babel.config.js using parserOptions.project)*

------
https://chatgpt.com/codex/tasks/task_b_68ad15f4c1b0832988b3bb87e46d0101