### PR TITLE
Refine error handling and typings across stores and transaction page

### DIFF
--- a/q-srfm/src/pages/VerifyEmailPage.vue
+++ b/q-srfm/src/pages/VerifyEmailPage.vue
@@ -36,8 +36,8 @@ onMounted(async () => {
       throw new Error(await response.text());
     }
     loading.value = false;
-  } catch (err: any) {
-    error.value = err.message || 'Verification failed';
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : 'Verification failed';
     loading.value = false;
   }
 });

--- a/q-srfm/src/store/auth.ts
+++ b/q-srfm/src/store/auth.ts
@@ -43,9 +43,9 @@ export const useAuthStore = defineStore('auth', () => {
     try {
       authError.value = null;
       user.value = await signInWithGoogle();
-    } catch (error: any) {
+    } catch (error) {
       console.error('Google login error:', error);
-      authError.value = error.message;
+      authError.value = error instanceof Error ? error.message : String(error);
       throw error;
     }
   }
@@ -55,9 +55,9 @@ export const useAuthStore = defineStore('auth', () => {
       authError.value = null;
       const userCredential = await signInWithCustomToken(auth, token);
       user.value = userCredential.user;
-    } catch (error: any) {
+    } catch (error) {
       console.error('Custom token login error:', error);
-      authError.value = error.message;
+      authError.value = error instanceof Error ? error.message : String(error);
       throw error;
     }
   }
@@ -67,9 +67,9 @@ export const useAuthStore = defineStore('auth', () => {
       await auth.signOut();
       user.value = null;
       authError.value = null;
-    } catch (error: any) {
+    } catch (error) {
       console.error('Logout error:', error);
-      authError.value = error.message;
+      authError.value = error instanceof Error ? error.message : String(error);
       throw error;
     }
   }
@@ -78,9 +78,9 @@ export const useAuthStore = defineStore('auth', () => {
     try {
       const currentUser = user.value;
       return currentUser ? await currentUser.getIdToken(true) : null;
-    } catch (error: any) {
+    } catch (error) {
       console.error('Get ID token error:', error);
-      authError.value = error.message;
+      authError.value = error instanceof Error ? error.message : String(error);
       return null;
     }
   }

--- a/q-srfm/src/store/budget.ts
+++ b/q-srfm/src/store/budget.ts
@@ -19,7 +19,7 @@ export const useBudgetStore = defineStore("budgets", () => {
         }
       }
       budgets.value = newBudgets;
-    } catch (error: any) {
+    } catch (error) {
       console.error("Error loading budgets:", error);
     }
   }

--- a/q-srfm/src/store/entities.ts
+++ b/q-srfm/src/store/entities.ts
@@ -21,7 +21,7 @@ export const useFamilyStore = defineStore("family", () => {
         }
         return f;
       }
-    } catch (error: any) {
+    } catch (error) {
       console.error("Error loading Family", error);
     }
     return null;
@@ -33,7 +33,7 @@ export const useFamilyStore = defineStore("family", () => {
         await loadFamily();
       }
       return family.value;
-    } catch (error: any) {
+    } catch (error) {
       console.error("Error getting Family", error);
     }
     return null;
@@ -50,7 +50,7 @@ export const useFamilyStore = defineStore("family", () => {
         }
       }
       return response.entityId;
-    } catch (error: any) {
+    } catch (error) {
       console.error("Error creating entity", error);
       throw error;
     }
@@ -64,7 +64,7 @@ export const useFamilyStore = defineStore("family", () => {
           e.id === entity.id ? entity : e
         ) || [];
       }
-    } catch (error: any) {
+    } catch (error) {
       console.error("Error updating entity", error);
       throw error;
     }
@@ -79,7 +79,7 @@ export const useFamilyStore = defineStore("family", () => {
           selectedEntityId.value = family.value.entities[0]?.id || "";
         }
       }
-    } catch (error: any) {
+    } catch (error) {
       console.error("Error deleting entity", error);
       throw error;
     }
@@ -97,7 +97,7 @@ export const useFamilyStore = defineStore("family", () => {
           }
         }
       }
-    } catch (error: any) {
+    } catch (error) {
       console.error("Error adding entity member", error);
       throw error;
     }
@@ -112,7 +112,7 @@ export const useFamilyStore = defineStore("family", () => {
           entity.members = entity.members?.filter(m => m.uid !== memberUid) || [];
         }
       }
-    } catch (error: any) {
+    } catch (error) {
       console.error("Error removing entity member", error);
       throw error;
     }


### PR DESCRIPTION
## Summary
- clean up TransactionsPage imports and queues, remove unused code, and harden error handling
- tidy VerifyEmailPage and stores with safer catch blocks
- strengthen DataAccess typing and carryover logic

## Testing
- `npx eslint -c eslint.config.js src/dataAccess.ts src/pages/TransactionsPage.vue src/pages/VerifyEmailPage.vue src/store/auth.ts src/store/budget.ts src/store/entities.ts`
- `yarn lint` *(fails: 138 problems across project)*
- `npx vue-tsc --noEmit` *(fails: missing module declarations)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_b_68b2407561e083299abb120a2bab9587