### PR TITLE
fix: resolve lint warnings

### DIFF
--- a/q-srfm/src/boot/banner.ts
+++ b/q-srfm/src/boot/banner.ts
@@ -5,7 +5,6 @@ export default boot(() => {
   const name = 'q-srfm';
   const mode = import.meta.env.MODE;
   const base = import.meta.env.BASE_URL;
-  // eslint-disable-next-line no-console
   console.log(`\n=============================\n  Starting ${name} (${mode})\n  Version: ${version}\n  Base URL: ${base}\n=============================\n`);
 });
 

--- a/q-srfm/src/components/EntitySelector.vue
+++ b/q-srfm/src/components/EntitySelector.vue
@@ -47,11 +47,9 @@ function selectEntity(id: string) {
 const DBG = '[EntitySelector]';
 // Btn+QMenu handles toggling; keep diagnostic hooks
 function onMenuShow() {
-  // eslint-disable-next-line no-console
   console.debug(DBG, 'menu show');
 }
 function onMenuHide() {
-  // eslint-disable-next-line no-console
   console.debug(DBG, 'menu hide');
 }
 </script>

--- a/q-srfm/src/pages/DashboardPage.vue
+++ b/q-srfm/src/pages/DashboardPage.vue
@@ -354,6 +354,7 @@ import DashboardTiles from '../components/DashboardTiles.vue';
 import SpendingByCategoryCard from '../components/charts/SpendingByCategoryCard.vue';
 import IncomeVsExpensesCard from '../components/charts/IncomeVsExpensesCard.vue';
 import type { Transaction, Budget, IncomeTarget, BudgetCategoryTrx, BudgetCategory } from '../types';
+import { EntityType } from '../types';
 import version from '../version';
 import { toDollars, toCents, formatCurrency, adjustTransactionDate, todayISO, currentMonthISO } from '../utils/helpers';
 import { useAuthStore } from '../store/auth';
@@ -367,7 +368,6 @@ import { DEFAULT_BUDGET_TEMPLATES } from '../constants/budgetTemplates';
 // Structured logger for this page
 const DBG = '[Dashboard]';
 function log(...args: unknown[]) {
-  // eslint-disable-next-line no-console
   console.log(DBG, ...args);
 }
 
@@ -459,7 +459,7 @@ function matchesSelectedEntity(b: Budget) {
   if (!familyStore.selectedEntityId) return true;
   if (b.entityId) return b.entityId === familyStore.selectedEntityId;
   // Some legacy family budgets may have no entityId; treat them as the Family entity
-  return selectedEntity.value?.type === 'Family';
+  return selectedEntity.value?.type === EntityType.Family;
 }
 
 const budgetedExpenses = computed(() => {
@@ -1120,11 +1120,6 @@ async function selectMonth(month: string) {
   }
 }
 
-// Targeted logging for Month selector
-function onMonthToggle() {
-  menuOpen.value = true;
-  log('Month toggle clicked, opening menu');
-}
 function onMonthMenuShow() {
   log('Month menu shown');
 }

--- a/q-srfm/src/pages/SettingsPage.vue
+++ b/q-srfm/src/pages/SettingsPage.vue
@@ -723,6 +723,14 @@ function showSnackbar(text: string, color = "success") {
   });
 }
 
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error
+    ? error.message
+    : typeof error === 'string'
+      ? error
+      : JSON.stringify(error);
+}
+
 async function syncNow() {
   syncing.value = true;
   try {
@@ -730,7 +738,7 @@ async function syncNow() {
     showSnackbar(msg || 'Sync completed successfully', 'positive');
   } catch (error: unknown) {
     console.error('Sync error:', error);
-    const msg = error instanceof Error ? error.message : String(error);
+    const msg = toErrorMessage(error);
     showSnackbar(`Sync failed: ${msg}`, 'negative');
   } finally {
     syncing.value = false;
@@ -753,7 +761,7 @@ async function syncIncrementalNow() {
     showSnackbar(label, 'positive');
   } catch (error: unknown) {
     console.error('Incremental sync error:', error);
-    const msg = error instanceof Error ? error.message : String(error);
+    const msg = toErrorMessage(error);
     showSnackbar(`Incremental sync failed: ${msg}`, 'negative');
   } finally {
     syncingIncremental.value = false;


### PR DESCRIPTION
## Summary
- clean up unused `no-console` disables and add error message helper
- remove unused month toggle and ensure entity comparisons use enum type

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b2f0e0cb348329addef17680c371d1