### PR TITLE
feat: virtualized transactions ledger

### DIFF
--- a/q-srfm/package.json
+++ b/q-srfm/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint -c ./eslint.config.js \"./src*/**/*.{ts,js,cjs,mjs,vue}\"",
     "format": "prettier --write \"**/*.{js,ts,vue,scss,html,md,json}\" --ignore-path .gitignore",
-    "test": "echo \"No test specified\" && exit 0",
+    "test": "tsc -p tsconfig.tests.json && node --test --experimental-specifier-resolution=node dist-tests/tests",
     "dev": "quasar dev",
     "build": "quasar build",
     "postinstall": "quasar prepare"

--- a/q-srfm/src/components/LedgerTable.vue
+++ b/q-srfm/src/components/LedgerTable.vue
@@ -1,0 +1,96 @@
+<template>
+  <q-table
+    :rows="rows"
+    :columns="columns"
+    row-key="id"
+    flat
+    dense
+    virtual-scroll
+    :virtual-scroll-item-size="rowHeight"
+    :loading="loading"
+    class="ledger-table"
+    @virtual-scroll="onVirtualScroll"
+  >
+    <!-- Amount cell formatting -->
+    <template #body-cell-amount="{ value, props }">
+      <q-td :props="props" class="text-right">
+        <span :class="value < 0 ? 'text-negative' : ''">{{ formatCurrency(value) }}</span>
+      </q-td>
+    </template>
+
+    <!-- Status badge -->
+    <template #body-cell-status="{ row, props }">
+      <q-td :props="props">
+        <q-badge
+          v-if="row.status === 'C'"
+          color="positive"
+          text-color="white"
+          dense
+          aria-label="Cleared"
+        >C</q-badge>
+        <q-badge
+          v-else-if="row.status === 'U'"
+          color="warning"
+          text-color="white"
+          dense
+          aria-label="Unmatched"
+        >U</q-badge>
+        <q-icon
+          v-if="row.isDuplicate"
+          name="warning"
+          color="warning"
+          size="16px"
+          class="q-ml-xs"
+          aria-label="Duplicate"
+        />
+      </q-td>
+    </template>
+
+    <!-- Default slot passthrough for additional customization -->
+    <slot />
+  </q-table>
+</template>
+
+<script setup lang="ts">
+import type { QTableProps } from 'quasar';
+import { formatCurrency } from 'src/utils/helpers';
+import { onBeforeUnmount } from 'vue';
+
+interface LedgerTableProps {
+  rows: Array<Record<string, unknown>>;
+  columns: QTableProps['columns'];
+  loading?: boolean;
+  fetchMore?: () => Promise<void> | void;
+  rowHeight?: number;
+}
+
+const props = withDefaults(defineProps<LedgerTableProps>(), {
+  loading: false,
+  rowHeight: 44,
+});
+
+function onVirtualScroll(info: { index: number; from: number; to: number }) {
+  if (props.fetchMore && !props.loading && info.to >= props.rows.length - 1) {
+    void props.fetchMore();
+  }
+}
+
+onBeforeUnmount(() => {
+  // allow parent to clean up if necessary
+});
+</script>
+
+<style scoped>
+.ledger-table thead th {
+  position: sticky;
+  top: 0;
+  background: white;
+  z-index: 1;
+}
+.ledger-table tbody tr:nth-child(even) {
+  background-color: #fafafa;
+}
+.ledger-table tbody tr.duplicate {
+  background-color: #FFF4E5;
+}
+</style>

--- a/q-srfm/src/components/MatchBankPanel.vue
+++ b/q-srfm/src/components/MatchBankPanel.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <q-tabs v-model="inner" dense>
+      <q-tab name="smart" label="Smart Matches" />
+      <q-tab name="remaining" label="Remaining" />
+    </q-tabs>
+    <q-tab-panels v-model="inner" animated>
+      <q-tab-panel name="smart">
+        <q-table
+          :rows="smartMatches"
+          :columns="columns"
+          row-key="id"
+          dense
+          flat
+          virtual-scroll
+          :virtual-scroll-item-size="44"
+          selection="multiple"
+          v-model:selected="selected"
+        />
+      </q-tab-panel>
+      <q-tab-panel name="remaining">
+        <q-table
+          :rows="remaining"
+          :columns="columns"
+          row-key="id"
+          dense
+          flat
+          virtual-scroll
+          :virtual-scroll-item-size="44"
+          selection="multiple"
+          v-model:selected="selected"
+        />
+      </q-tab-panel>
+    </q-tab-panels>
+    <q-footer v-if="selected.length" class="bg-white q-pa-sm shadow-2">
+      <div class="row items-center">
+        <div class="col">{{ selected.length }} selected</div>
+        <q-btn color="primary" label="Confirm" @click="confirm" />
+      </div>
+    </q-footer>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useImported } from 'src/composables/useImported';
+import type { ImportedTransaction } from 'src/composables/useImported';
+
+const inner = ref<'smart' | 'remaining'>('smart');
+const selected = ref<ImportedTransaction[]>([]);
+
+const { smartMatches, remaining, confirmMatches } = useImported();
+
+const columns = [
+  { name: 'bankDate', label: 'Bank Date', field: 'bankDate', align: 'left' },
+  { name: 'bankAmount', label: 'Bank Amount', field: 'bankAmount', align: 'right' },
+  { name: 'bankPayee', label: 'Payee', field: 'bankPayee', align: 'left' },
+];
+
+function confirm() {
+  confirmMatches(selected.value.map((r) => r.id));
+  selected.value = [];
+}
+</script>

--- a/q-srfm/src/components/StatementHeader.vue
+++ b/q-srfm/src/components/StatementHeader.vue
@@ -1,0 +1,52 @@
+<template>
+  <q-card class="q-pa-sm q-mb-md">
+    <div class="row q-col-gutter-md items-center">
+      <q-select
+        class="col-3"
+        v-model="account"
+        :options="accounts"
+        label="Select Account"
+        dense
+        outlined
+        emit-value
+        map-options
+      />
+      <q-input class="col" v-model="range.start" label="Start" type="date" dense outlined />
+      <q-input class="col" v-model="range.end" label="End" type="date" dense outlined />
+      <q-input class="col" v-model.number="beginBalance" label="Beginning" dense outlined readonly />
+      <q-input class="col" v-model.number="endBalance" label="Ending" dense outlined />
+    </div>
+    <div class="row items-center q-mt-sm">
+      <div class="col">
+        Matched {{ matched.toLocaleString('en-US', { style: 'currency', currency: 'USD' }) }} /
+        {{ total.toLocaleString('en-US', { style: 'currency', currency: 'USD' }) }}
+        ({{ progress }}%)
+        <q-linear-progress :value="progress / 100" color="positive" class="q-mt-xs" />
+      </div>
+      <q-btn color="primary" label="Finalize Statement" class="col-auto" @click="finalize" />
+    </div>
+  </q-card>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+
+const account = ref('');
+const accounts = ref([
+  { label: 'Checking', value: 'checking' },
+  { label: 'Savings', value: 'savings' },
+]);
+const range = ref({ start: '', end: '' });
+const beginBalance = ref(1000);
+const endBalance = ref(0);
+const matched = ref(0);
+const total = ref(0);
+
+const progress = computed(() => {
+  return total.value === 0 ? 0 : Math.round((matched.value / total.value) * 100);
+});
+
+function finalize() {
+  // validation placeholder
+}
+</script>

--- a/q-srfm/src/composables/useImported.ts
+++ b/q-srfm/src/composables/useImported.ts
@@ -1,0 +1,49 @@
+import { ref } from 'vue';
+
+export interface ImportedTransaction {
+  id: string;
+  bankDate: string;
+  bankAmount: number;
+  type: 'debit' | 'credit';
+  bankPayee: string;
+  matchedBudgetTxId?: string;
+}
+
+function generateImported(count = 100): ImportedTransaction[] {
+  const arr: ImportedTransaction[] = [];
+  for (let i = 0; i < count; i++) {
+    arr.push({
+      id: `imp-${i}`,
+      bankDate: new Date(Date.now() - i * 86400000).toISOString().slice(0, 10),
+      bankAmount: parseFloat((Math.random() * 200 - 100).toFixed(2)),
+      type: 'debit',
+      bankPayee: `BankPayee ${i}`,
+    });
+  }
+  return arr;
+}
+
+const imported = generateImported();
+
+export function useImported() {
+  const smartMatches = ref(imported.slice(0, 20));
+  const remaining = ref(imported.slice(20));
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function listByAccount(_accountId: string) {
+    return imported.filter(() => true);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function smartMatchesFn(_windowDays: number) {
+    return smartMatches.value;
+  }
+
+  function confirmMatches(ids: string[]) {
+    // placeholder to remove confirmed ids
+    remaining.value = remaining.value.filter((r) => !ids.includes(r.id));
+    smartMatches.value = smartMatches.value.filter((r) => !ids.includes(r.id));
+  }
+
+  return { smartMatches, remaining, listByAccount, smartMatchesFn, confirmMatches } as const;
+}

--- a/q-srfm/src/composables/useStatements.ts
+++ b/q-srfm/src/composables/useStatements.ts
@@ -1,0 +1,40 @@
+import { ref } from 'vue';
+
+export interface Statement {
+  id: string;
+  accountId: string;
+  startDate: string;
+  endDate: string;
+  beginBalance: number;
+  endBalance: number;
+  matchedIds: string[];
+}
+
+export function useStatements() {
+  const current = ref<Statement | null>(null);
+
+  function getCurrent() {
+    return current.value;
+  }
+
+  function begin(accountId: string, range: { start: string; end: string }, beginBalance: number) {
+    current.value = {
+      id: 'stmt-1',
+      accountId,
+      startDate: range.start,
+      endDate: range.end,
+      beginBalance,
+      endBalance: 0,
+      matchedIds: [],
+    };
+    return current.value;
+  }
+
+  function finalize(statementId: string, endBalance: number) {
+    if (current.value && current.value.id === statementId) {
+      current.value.endBalance = endBalance;
+    }
+  }
+
+  return { current, getCurrent, begin, finalize } as const;
+}

--- a/q-srfm/src/composables/useTransactions.ts
+++ b/q-srfm/src/composables/useTransactions.ts
@@ -1,0 +1,146 @@
+import { ref } from 'vue';
+
+export interface TransactionBase {
+  id: string;
+  date: string; // ISO
+  payee: string;
+  categoryId: string;
+  entityId: string;
+  budgetId: string;
+  amount: number;
+  notes?: string;
+}
+
+export interface BudgetTransaction extends TransactionBase {
+  status: 'C' | 'U';
+  isDuplicate?: boolean;
+  linkId?: string;
+}
+
+export interface RegistryRow extends BudgetTransaction {
+  runningBalance?: number;
+}
+
+// mock generator
+function generateMock(count = 1000): BudgetTransaction[] {
+  const arr: BudgetTransaction[] = [];
+  for (let i = 0; i < count; i++) {
+    const amt = parseFloat((Math.random() * 200 - 100).toFixed(2));
+    arr.push({
+      id: `tx-${i}`,
+      date: new Date(Date.now() - i * 86400000).toISOString().slice(0, 10),
+      payee: `Merchant ${i % 20}`,
+      categoryId: `cat-${i % 5}`,
+      entityId: `ent-${i % 3}`,
+      budgetId: `bud-${i % 2}`,
+      amount: amt,
+      status: i % 3 === 0 ? 'C' : 'U',
+      notes: 'Sample note',
+    });
+  }
+  return arr;
+}
+
+const all = generateMock();
+
+export function useTransactions() {
+  const transactions = ref<BudgetTransaction[]>([]);
+  const registerRows = ref<RegistryRow[]>([]);
+  const page = ref(0);
+  const registerPage = ref(0);
+  const pageSize = 50;
+  const loading = ref(false);
+  const loadingRegister = ref(false);
+
+  function loadPage(target: typeof transactions, pageRef: typeof page) {
+    const start = pageRef.value * pageSize;
+    const next = all.slice(start, start + pageSize);
+    target.value.push(...next);
+    pageRef.value++;
+  }
+
+  function fetchMore() {
+    if (loading.value) return;
+    loading.value = true;
+    loadPage(transactions, page);
+    loading.value = false;
+  }
+
+  function fetchMoreRegister() {
+    if (loadingRegister.value) return;
+    loadingRegister.value = true;
+    const start = registerPage.value * pageSize;
+    const next = all.slice(start, start + pageSize).map((t) => ({
+      ...t,
+      runningBalance: (registerRows.value.at(-1)?.runningBalance || 0) + t.amount,
+    }));
+    registerRows.value.push(...next);
+    registerPage.value++;
+    loadingRegister.value = false;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function scrollToDate(_date: string) {
+    // no-op placeholder; would map date to index and scroll
+  }
+
+  // Columns for tables
+  const budgetColumns = [
+    { name: 'date', label: 'Date', field: 'date', align: 'left' },
+    { name: 'payee', label: 'Payee', field: 'payee', align: 'left' },
+    { name: 'category', label: 'Category', field: 'categoryId', align: 'left' },
+    { name: 'entity', label: 'Entity/Budget', field: 'entityId', align: 'left' },
+    { name: 'amount', label: 'Amount', field: 'amount', align: 'right' },
+    { name: 'status', label: 'Status', field: 'status', align: 'center' },
+    { name: 'notes', label: 'Notes', field: 'notes', align: 'left' },
+  ];
+
+  const registerColumns = [
+    ...budgetColumns,
+    { name: 'balance', label: 'Balance', field: 'runningBalance', align: 'right' },
+  ];
+
+  // seed initial
+  void fetchMore();
+  void fetchMoreRegister();
+
+  return {
+    transactions,
+    registerRows,
+    fetchMore,
+    fetchMoreRegister,
+    loading,
+    loadingRegister,
+    scrollToDate,
+    budgetColumns,
+    registerColumns,
+    withinDateWindow,
+    isDuplicate,
+    link,
+    unlink,
+  } as const;
+}
+
+// duplicate helper exported at module scope
+export function withinDateWindow(a: string, b: string, days: number) {
+  const diff = Math.abs(new Date(a).getTime() - new Date(b).getTime());
+  return diff <= days * 86400000;
+}
+
+export function isDuplicate(tx: BudgetTransaction, others: BudgetTransaction[], days = 3) {
+  return others.some(
+    (o) =>
+      o.id !== tx.id &&
+      o.payee === tx.payee &&
+      Math.abs(o.amount - tx.amount) <= 0.01 &&
+      withinDateWindow(tx.date, o.date, days)
+  );
+}
+
+export function link(tx: BudgetTransaction, importedId: string) {
+  tx.linkId = importedId;
+}
+
+export function unlink(tx: BudgetTransaction) {
+  delete tx.linkId;
+}

--- a/q-srfm/tests/transactions.test.ts
+++ b/q-srfm/tests/transactions.test.ts
@@ -1,0 +1,42 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore explicit .js import for Node after compilation
+import { withinDateWindow, isDuplicate, link, unlink, BudgetTransaction } from '../src/composables/useTransactions.js';
+
+test('withinDateWindow', () => {
+  assert.equal(withinDateWindow('2024-01-01', '2024-01-03', 3), true);
+  assert.equal(withinDateWindow('2024-01-01', '2024-01-05', 3), false);
+});
+
+test('isDuplicate', () => {
+  const t1: BudgetTransaction = {
+    id: '1',
+    date: '2024-01-01',
+    payee: 'A',
+    categoryId: 'c1',
+    entityId: 'e1',
+    budgetId: 'b1',
+    amount: -10,
+    status: 'U',
+  };
+  const t2: BudgetTransaction = { ...t1, id: '2' };
+  assert.equal(isDuplicate(t1, [t1, t2]), true);
+});
+
+test('link/unlink', () => {
+  const t: BudgetTransaction = {
+    id: '3',
+    date: '2024-01-01',
+    payee: 'B',
+    categoryId: 'c1',
+    entityId: 'e1',
+    budgetId: 'b1',
+    amount: 5,
+    status: 'U',
+  };
+  link(t, 'imp1');
+  assert.equal(t.linkId, 'imp1');
+  unlink(t);
+  assert.equal(t.linkId, undefined);
+});

--- a/q-srfm/tsconfig.tests.json
+++ b/q-srfm/tsconfig.tests.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "skipLibCheck": true,
+    "outDir": "dist-tests"
+  },
+  "include": ["src/composables/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- refactor Transactions page with tabbed ledger, register, and bank match panels
- add virtualized `LedgerTable` with sticky headers and status badges
- introduce mock composables for transactions, imports, and statements with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b3057c86588329928c90ca4ed3a7df