### PR TITLE
Fix table slot typing and QFile v-model requirements

### DIFF
--- a/q-srfm/src/components/LedgerTable.vue
+++ b/q-srfm/src/components/LedgerTable.vue
@@ -12,31 +12,31 @@
     @virtual-scroll="onVirtualScroll"
   >
     <!-- Amount cell formatting -->
-    <template #body-cell-amount="{ value, props }">
-      <q-td :props="props" class="text-right">
-        <span :class="value < 0 ? 'text-negative' : ''">{{ formatCurrency(value) }}</span>
+    <template #body-cell-amount="slotProps">
+      <q-td :props="slotProps" class="text-right">
+        <span :class="slotProps.value < 0 ? 'text-negative' : ''">{{ formatCurrency(slotProps.value) }}</span>
       </q-td>
     </template>
 
     <!-- Status badge -->
-    <template #body-cell-status="{ row, props }">
-      <q-td :props="props">
+    <template #body-cell-status="slotProps">
+      <q-td :props="slotProps">
         <q-badge
-          v-if="row.status === 'C'"
+          v-if="slotProps.row.status === 'C'"
           color="positive"
           text-color="white"
           dense
           aria-label="Cleared"
         >C</q-badge>
         <q-badge
-          v-else-if="row.status === 'U'"
+          v-else-if="slotProps.row.status === 'U'"
           color="warning"
           text-color="white"
           dense
           aria-label="Unmatched"
         >U</q-badge>
         <q-icon
-          v-if="row.isDuplicate"
+          v-if="slotProps.row.isDuplicate"
           name="warning"
           color="warning"
           size="16px"

--- a/q-srfm/src/components/MatchBankPanel.vue
+++ b/q-srfm/src/components/MatchBankPanel.vue
@@ -45,13 +45,14 @@
 import { ref } from 'vue';
 import { useImported } from 'src/composables/useImported';
 import type { ImportedTransaction } from 'src/composables/useImported';
+import type { QTableColumn } from 'quasar';
 
 const inner = ref<'smart' | 'remaining'>('smart');
 const selected = ref<ImportedTransaction[]>([]);
 
 const { smartMatches, remaining, confirmMatches } = useImported();
 
-const columns = [
+const columns: QTableColumn[] = [
   { name: 'bankDate', label: 'Bank Date', field: 'bankDate', align: 'left' },
   { name: 'bankAmount', label: 'Bank Amount', field: 'bankAmount', align: 'right' },
   { name: 'bankPayee', label: 'Payee', field: 'bankPayee', align: 'left' },

--- a/q-srfm/src/composables/useTransactions.ts
+++ b/q-srfm/src/composables/useTransactions.ts
@@ -1,4 +1,5 @@
 import { ref } from 'vue';
+import type { QTableColumn } from 'quasar';
 
 export interface TransactionBase {
   id: string;
@@ -85,7 +86,7 @@ export function useTransactions() {
   }
 
   // Columns for tables
-  const budgetColumns = [
+  const budgetColumns: QTableColumn[] = [
     { name: 'date', label: 'Date', field: 'date', align: 'left' },
     { name: 'payee', label: 'Payee', field: 'payee', align: 'left' },
     { name: 'category', label: 'Category', field: 'categoryId', align: 'left' },
@@ -95,7 +96,7 @@ export function useTransactions() {
     { name: 'notes', label: 'Notes', field: 'notes', align: 'left' },
   ];
 
-  const registerColumns = [
+  const registerColumns: QTableColumn[] = [
     ...budgetColumns,
     { name: 'balance', label: 'Balance', field: 'runningBalance', align: 'right' },
   ];

--- a/q-srfm/src/pages/DataPage.vue
+++ b/q-srfm/src/pages/DataPage.vue
@@ -75,6 +75,7 @@
                   <div class="row">
                     <div class="col col-12 col-md-6">
                       <q-file
+                        v-model="bankTransactionsFile"
                         label="Upload Bank/Card Transactions CSV"
                         accept=".csv"
                         @change="handleBankTransactionsFileUpload"
@@ -207,10 +208,17 @@
                   </div>
                 </div>
                 <div v-else-if="importType === 'entities'">
-                  <q-file label="Upload Entities CSV/JSON" accept=".csv,.json" @change="handleFileUpload" :disabled="importing"></q-file>
+                  <q-file
+                    v-model="entitiesFile"
+                    label="Upload Entities CSV/JSON"
+                    accept=".csv,.json"
+                    @change="handleFileUpload"
+                    :disabled="importing"
+                  ></q-file>
                 </div>
                 <div v-else-if="importType === 'accountsAndSnapshots'">
                   <q-file
+                    v-model="accountsSnapshotsFile"
                     label="Upload Accounts and Snapshots CSV"
                     accept=".csv"
                     @change="handleAccountsAndSnapshotsImport"
@@ -219,6 +227,7 @@
                 </div>
                 <div v-else>
                   <q-file
+                    v-model="selectedFiles"
                     label="Upload Budget or Transactions CSV/JSON"
                     accept=".csv,.json"
                     multiple
@@ -402,6 +411,9 @@ const importTypes = [
   { title: "Accounts/Snapshots", value: "accountsAndSnapshots" },
 ];
 const selectedFiles = ref<File[]>([]);
+const bankTransactionsFile = ref<File | null>(null);
+const entitiesFile = ref<File | null>(null);
+const accountsSnapshotsFile = ref<File | null>(null);
 
 // Bank/Card Transactions Import
 const previewBankTransactions = ref<any[]>([]);


### PR DESCRIPTION
## Summary
- Use slot props directly in `LedgerTable` slots to satisfy Vue/Quasar typing
- Type Quasar table column definitions with `QTableColumn`
- Add missing `v-model` bindings to `QFile` inputs and supporting refs

## Testing
- `npm run lint`
- `npm test`
- `npx vue-tsc --noEmit` *(fails: Cannot find module 'papaparse' or 'file-saver')*

------
https://chatgpt.com/codex/tasks/task_b_68b34c84f91c8329b101cb4efd602986