### PR TITLE
feat(transactions): enable multi-month budget selection

### DIFF
--- a/app/src/store/ui.ts
+++ b/app/src/store/ui.ts
@@ -11,7 +11,7 @@ export const useUIStore = defineStore("uiState", () => {
   const filterStartDate = ref("");
   const filterEndDate = ref("");
 
-  // Budget Entries filters
+  // Budget Transactions filters
   const entriesSearch = ref("");
   const entriesFilterMerchant = ref("");
   const entriesFilterAmount = ref("");

--- a/app/src/views/TransactionsView.vue
+++ b/app/src/views/TransactionsView.vue
@@ -10,12 +10,12 @@
 
     <!-- Tabs -->
     <v-tabs v-model="tab" :color="isMobile ? 'white' : 'primary'">
-      <v-tab value="entries">Budget Entries</v-tab>
+      <v-tab value="entries">Budget Transactions</v-tab>
       <v-tab value="register">Register</v-tab>
     </v-tabs>
 
     <v-window v-model="tab">
-      <!-- Budget Entries -->
+      <!-- Budget Transactions -->
       <v-window-item class="bg-white" value="entries">
         <!-- Add Transaction Button -->
         <v-btn v-if="isMobile" color="primary" variant="plain" @click="showTransactionDialog = true" icon="mdi-plus"></v-btn>
@@ -60,6 +60,7 @@
                   item-value="budgetId"
                   variant="outlined"
                   multiple
+                  chips
                   clearable
                   :disabled="budgetOptions.length === 0"
                   @update:modelValue="loadTransactions"
@@ -183,7 +184,7 @@
         </v-card>
 
         <v-card density="compact">
-          <v-card-title>Budget Entries</v-card-title>
+          <v-card-title>Budget Transactions</v-card-title>
           <v-list dense>
             <v-list-item v-for="transaction in expenseTransactions" :key="transaction.id" class="transaction-item" :class="{ 'deleted-transaction': transaction.deleted }" @click="editTransaction(transaction)">
               <!-- Desktop Layout -->
@@ -389,7 +390,7 @@ import MatchBudgetTransactionDialog from "../components/MatchBudgetTransactionDi
 import TransactionRegistry from "../components/TransactionRegistry.vue";
 import EntitySelector from "../components/EntitySelector.vue";
 import { Transaction, BudgetInfo, ImportedTransaction, Account, Entity } from "../types";
-import { formatDateLong, toDollars, toCents, formatCurrency, toBudgetMonth, todayISO } from "../utils/helpers";
+import { formatDateLong, toDollars, toCents, formatCurrency, toBudgetMonth, todayISO, formatDateMonthYYYY } from "../utils/helpers";
 import { useBudgetStore } from "../store/budget";
 import { useFamilyStore } from "../store/family";
 import { useUIStore } from "../store/ui";
@@ -582,12 +583,12 @@ const unmatchedImportedTransactions = computed(() => {
 
 const budgetOptions = computed(() => {
   return Array.from(budgetStore.budgets.entries())
+    .sort((a, b) => b[1].month.localeCompare(a[1].month))
     .map(([budgetId, budget]) => ({
       budgetId,
-      month: budget.month,
+      month: formatDateMonthYYYY(budget.month),
       familyId: budget.familyId,
-    }))
-    .sort((a, b) => b.month.localeCompare(a.month));
+    }));
 });
 
 onMounted(async () => {

--- a/q-srfm/src/store/ui.ts
+++ b/q-srfm/src/store/ui.ts
@@ -11,7 +11,7 @@ export const useUIStore = defineStore("uiState", () => {
   const filterStartDate = ref("");
   const filterEndDate = ref("");
 
-  // Budget Entries filters
+  // Budget Transactions filters
   const entriesSearch = ref("");
   const entriesFilterMerchant = ref("");
   const entriesFilterAmount = ref("");

--- a/quasar/src/pages/TransactionsPage.vue
+++ b/quasar/src/pages/TransactionsPage.vue
@@ -6,12 +6,12 @@
 
     <!-- Tabs -->
     <q-tabs v-model="tab" color="primary">
-      <q-tab name="entries">Budget Entries</q-tab>
+      <q-tab name="entries">Budget Transactions</q-tab>
       <q-tab name="register">Transaction Register</q-tab>
     </q-tabs>
 
     <q-tab-panels v-model="tab">
-      <!-- Budget Entries -->
+      <!-- Budget Transactions -->
       <q-tab-panel name="entries">
         <!-- Add Transaction Button -->
         <q-btn color="primary" variant="plain" class="mb-4 mr-2" @click="showTransactionDialog = true"> Add Transaction </q-btn>
@@ -45,6 +45,7 @@
                   item-value="budgetId"
                   variant="outlined"
                   multiple
+                  use-chips
                   clearable
                   :disabled="budgetOptions.length === 0"
                   @update:modelValue="loadTransactions"
@@ -167,7 +168,7 @@
         </q-card>
 
         <q-card density="compact">
-          <q-card-section>Budget Entries</q-card-section>
+          <q-card-section>Budget Transactions</q-card-section>
           <q-list dense>
             <q-item v-for="transaction in expenseTransactions" :key="transaction.id" class="transaction-item" :class="{ 'deleted-transaction': transaction.deleted }" @click="editTransaction(transaction)">
               <!-- Desktop Layout -->
@@ -364,7 +365,7 @@ import MatchBudgetTransactionDialog from '../components/MatchBudgetTransactionDi
 import TransactionRegistry from '../components/TransactionRegistry.vue';
 import EntitySelector from '../components/EntitySelector.vue';
 import { Transaction, BudgetInfo, ImportedTransaction, Account, Entity } from '../types';
-import { formatDateLong, toDollars, toCents, formatCurrency, toBudgetMonth, todayISO } from '../utils/helpers';
+import { formatDateLong, toDollars, toCents, formatCurrency, toBudgetMonth, todayISO, formatDateMonthYYYY } from '../utils/helpers';
 import { useBudgetStore } from '../store/budget';
 import { useFamilyStore } from '../store/family';
 import { useUIStore } from '../store/ui';
@@ -554,12 +555,12 @@ const unmatchedImportedTransactions = computed(() => {
 
 const budgetOptions = computed(() => {
   return Array.from(budgetStore.budgets.entries())
+    .sort((a, b) => b[1].month.localeCompare(a[1].month))
     .map(([budgetId, budget]) => ({
       budgetId,
-      month: budget.month,
+      month: formatDateMonthYYYY(budget.month),
       familyId: budget.familyId,
-    }))
-    .sort((a, b) => b.month.localeCompare(a.month));
+    }));
 });
 
 onMounted(async () => {

--- a/quasar/src/store/ui.ts
+++ b/quasar/src/store/ui.ts
@@ -11,7 +11,7 @@ export const useUIStore = defineStore("uiState", () => {
   const filterStartDate = ref("");
   const filterEndDate = ref("");
 
-  // Budget Entries filters
+  // Budget Transactions filters
   const entriesSearch = ref("");
   const entriesFilterMerchant = ref("");
   const entriesFilterAmount = ref("");


### PR DESCRIPTION
## Summary
- format budget months for display and allow multi-select chips on Transactions screens
- rename Budget Entries tab and section to Budget Transactions

## Testing
- `cd quasar && npm test`
- `cd app && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b359154b348329a4cc75cb0aff29c7