### PR TITLE
feat(logging): persist api logs to supabase

### DIFF
--- a/api/Logging/SupabaseLogger.cs
+++ b/api/Logging/SupabaseLogger.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Npgsql;
+using FamilyBudgetApi.Services;
+
+namespace FamilyBudgetApi.Logging;
+
+/// <summary>
+/// Logger that writes entries to a Supabase/PostgreSQL table named "logs".
+/// </summary>
+public class SupabaseLogger : ILogger
+{
+    private readonly string _categoryName;
+    private readonly SupabaseDbService _dbService;
+
+    public SupabaseLogger(string categoryName, SupabaseDbService dbService)
+    {
+        _categoryName = categoryName;
+        _dbService = dbService;
+    }
+
+    public IDisposable BeginScope<TState>(TState state) => null!;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+        Exception exception, Func<TState, Exception, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+            return;
+
+        var message = formatter(state, exception);
+        _ = WriteLogAsync(logLevel, message, exception);
+    }
+
+    private async Task WriteLogAsync(LogLevel level, string message, Exception exception)
+    {
+        try
+        {
+            await using var conn = await _dbService.GetOpenConnectionAsync();
+            const string sql = "INSERT INTO logs (timestamp, level, category, message, exception) VALUES (@timestamp, @level, @category, @message, @exception);";
+            await using var cmd = new NpgsqlCommand(sql, conn);
+            cmd.Parameters.AddWithValue("@timestamp", DateTime.UtcNow);
+            cmd.Parameters.AddWithValue("@level", level.ToString());
+            cmd.Parameters.AddWithValue("@category", _categoryName);
+            cmd.Parameters.AddWithValue("@message", message);
+            cmd.Parameters.AddWithValue("@exception", (object?)exception?.ToString() ?? DBNull.Value);
+            await cmd.ExecuteNonQueryAsync();
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error writing log to Supabase: {ex.Message}");
+        }
+    }
+}

--- a/api/Logging/SupabaseLoggerProvider.cs
+++ b/api/Logging/SupabaseLoggerProvider.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Logging;
+using FamilyBudgetApi.Services;
+
+namespace FamilyBudgetApi.Logging;
+
+/// <summary>
+/// Logger provider that creates <see cref="SupabaseLogger"/> instances.
+/// </summary>
+public class SupabaseLoggerProvider : ILoggerProvider
+{
+    private readonly SupabaseDbService _dbService;
+
+    public SupabaseLoggerProvider(SupabaseDbService dbService)
+    {
+        _dbService = dbService;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new SupabaseLogger(categoryName, _dbService);
+    }
+
+    public void Dispose() { }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -74,7 +74,9 @@ builder.Services.AddControllers()
     });
 
 // Register application services
-builder.Services.AddSingleton<SupabaseDbService>();
+var supabaseDbService = new SupabaseDbService(builder.Configuration);
+builder.Services.AddSingleton(supabaseDbService);
+builder.Logging.AddProvider(new SupabaseLoggerProvider(supabaseDbService));
 builder.Services.AddSingleton<FamilyService>();
 builder.Services.AddSingleton<BudgetService>();
 builder.Services.AddSingleton<UserService>();


### PR DESCRIPTION
## Summary
- add SupabaseLogger and provider for storing log entries in Supabase
- wire up Supabase logging in API startup configuration

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68b35b415750832995c3f22b71323c6c