### PR TITLE
Default to current budget on transactions page

### DIFF
--- a/q-srfm/package.json
+++ b/q-srfm/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint -c ./eslint.config.js \"./src*/**/*.{ts,js,cjs,mjs,vue}\"",
     "format": "prettier --write \"**/*.{js,ts,vue,scss,html,md,json}\" --ignore-path .gitignore",
-    "test": "tsc -p tsconfig.tests.json && node --test --experimental-specifier-resolution=node dist-tests/tests",
+    "test": "tsc -p tsconfig.tests.json && node scripts/prep-tests.js && node --test dist-tests/tests",
     "dev": "quasar dev",
     "build": "quasar build",
     "postinstall": "quasar prepare"

--- a/q-srfm/scripts/prep-tests.js
+++ b/q-srfm/scripts/prep-tests.js
@@ -1,0 +1,17 @@
+import { readdirSync, statSync, copyFileSync } from 'fs';
+import { join } from 'path';
+
+function copyRecursive(dir) {
+  for (const f of readdirSync(dir)) {
+    const p = join(dir, f);
+    const st = statSync(p);
+    if (st.isDirectory()) copyRecursive(p);
+    else if (p.endsWith('.js')) {
+      copyFileSync(p, p.slice(0, -3));
+    }
+  }
+}
+
+try {
+  copyRecursive('dist-tests/src');
+} catch {}

--- a/q-srfm/src/components/LedgerTable.vue
+++ b/q-srfm/src/components/LedgerTable.vue
@@ -4,9 +4,10 @@
     :columns="visibleColumns"
     row-key="id"
     flat
-    bordered
-    dense
+  bordered
+  dense
     class="ledger-table"
+    :style="{ '--header-offset': `${headerOffset}px` }"
     :virtual-scroll="true"
     :virtual-scroll-item-size="rowHeight"
     :rows-per-page-options="[0]"
@@ -81,11 +82,13 @@ const props = defineProps<{
   canLoadMore?: boolean;
   loadingMore?: boolean;
   rowHeight?: number;
+  headerOffset?: number;
 }>();
 
 const emit = defineEmits<{ (e: 'load-more'): void }>();
 
 const rowHeight = computed(() => props.rowHeight ?? 44);
+const headerOffset = computed(() => props.headerOffset ?? 0);
 
 const baseColumns: Column<LedgerRow>[] = [
   { name: 'date', label: 'Date', field: 'date', align: 'left', sortable: true },
@@ -130,7 +133,7 @@ onMounted(() => {
 <style scoped>
 .ledger-table thead tr {
   position: sticky;
-  top: 0;
+  top: var(--header-offset);
   z-index: 2;
   background: #fff;
 }

--- a/q-srfm/src/components/LedgerTable.vue
+++ b/q-srfm/src/components/LedgerTable.vue
@@ -17,6 +17,18 @@
       <slot name="header"></slot>
     </template>
 
+    <template #header="props">
+      <q-tr :props="props">
+        <q-th
+          v-for="col in props.cols"
+          :key="col.name"
+          :props="props"
+        >
+          {{ col.label }}
+        </q-th>
+      </q-tr>
+    </template>
+
     <template #body="props">
       <q-tr :props="props" :class="[{ 'dup-row': props.row.isDuplicate }, 'row-striped']">
         <q-td key="date" :props="props" class="col-date">{{ formatDate(props.row.date) }}</q-td>
@@ -29,6 +41,7 @@
         <q-td key="status" :props="props" class="col-status">
           <q-badge v-if="props.row.status === 'C'" color="positive" outline> C </q-badge>
           <q-badge v-else-if="props.row.status === 'U'" color="warning" outline> U </q-badge>
+          <q-badge v-else-if="props.row.status === 'R'" color="primary" outline> R </q-badge>
           <q-icon v-if="props.row.linkId" name="link" color="primary" size="16px" class="q-ml-xs" />
           <q-icon v-if="props.row.isDuplicate" name="warning" color="warning" size="16px" class="q-ml-xs" />
         </q-td>
@@ -70,10 +83,12 @@ export interface LedgerRow {
   entityName: string;
   budgetId: string;
   amount: number; // dollars
-  status: 'C' | 'U';
+  status: 'C' | 'U' | 'R';
+  importedMerchant?: string;
   isDuplicate?: boolean;
   linkId?: string;
   notes?: string;
+  accountId?: string;
 }
 
 const props = defineProps<{

--- a/q-srfm/src/components/LedgerTable.vue
+++ b/q-srfm/src/components/LedgerTable.vue
@@ -64,7 +64,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted } from 'vue';
+import { computed, ref, onMounted, watch } from 'vue';
 type Align = 'left' | 'right' | 'center';
 // Generic column typing to avoid any
 export type Column<Row = Record<string, unknown>> = {
@@ -98,6 +98,7 @@ const props = defineProps<{
   loadingMore?: boolean;
   rowHeight?: number;
   headerOffset?: number;
+  entityLabel?: string;
 }>();
 
 const emit = defineEmits<{ (e: 'load-more'): void }>();
@@ -105,44 +106,53 @@ const emit = defineEmits<{ (e: 'load-more'): void }>();
 const rowHeight = computed(() => props.rowHeight ?? 44);
 const headerOffset = computed(() => props.headerOffset ?? 0);
 
-const baseColumns: Column<LedgerRow>[] = [
+const baseColumns = computed<Column<LedgerRow>[]>(() => [
   { name: 'date', label: 'Date', field: 'date', align: 'left', sortable: true },
   { name: 'payee', label: 'Payee', field: 'payee', align: 'left', sortable: true },
   { name: 'category', label: 'Category', field: 'category', align: 'left' },
-  { name: 'entity', label: 'Entity/Budget', field: 'entityName', align: 'left' },
+  { name: 'entity', label: props.entityLabel ?? 'Entity/Budget', field: 'entityName', align: 'left' },
   { name: 'amount', label: 'Amount', field: 'amount', align: 'right', sortable: true },
   { name: 'status', label: 'Status', field: 'status', align: 'left' },
   { name: 'notes', label: 'Notes', field: 'notes', align: 'left' },
   { name: 'actions', label: '', field: 'id', align: 'right' },
-];
+]);
 
-const visibleColumns = ref<Column<LedgerRow>[]>(baseColumns);
+const visibleColumns = ref<Column<LedgerRow>[]>([]);
+
+function updateCols(mq: MediaQueryList) {
+  const cols = baseColumns.value;
+  visibleColumns.value = mq.matches
+    ? cols.filter((c) => !['category', 'notes'].includes(c.name))
+    : cols;
+}
+
+onMounted(() => {
+  const mq = window.matchMedia('(max-width: 768px)');
+  const handler = () => updateCols(mq);
+  handler();
+  mq.addEventListener?.('change', handler);
+});
+
+watch(baseColumns, () => {
+  const mq = window.matchMedia('(max-width: 768px)');
+  updateCols(mq);
+});
 
 function money(n: number) {
   return (n < 0 ? '-$' : '$') + Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 function formatDate(iso: string) {
   const d = new Date(iso);
-  return d.toLocaleDateString('en-US');
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  });
 }
 
 function onLoadMore() {
   emit('load-more');
 }
-
-onMounted(() => {
-  // Responsive columns: hide notes on xs
-  const mq = window.matchMedia('(max-width: 768px)');
-  const updateCols = () => {
-    if (mq.matches) {
-      visibleColumns.value = baseColumns.filter((c) => !['category', 'notes'].includes(c.name));
-    } else {
-      visibleColumns.value = baseColumns;
-    }
-  };
-  updateCols();
-  mq.addEventListener?.('change', updateCols);
-});
 </script>
 
 <style scoped>

--- a/q-srfm/src/composables/useTransactions.ts
+++ b/q-srfm/src/composables/useTransactions.ts
@@ -119,16 +119,12 @@ export function useTransactions() {
   async function hydrateBudgets(budgetIds: string[]) {
     const out: LedgerRow[] = [];
     for (const id of budgetIds) {
-      let b = budgetStore.getBudget(id);
-      if (!b || !Array.isArray(b.categories) || !Array.isArray(b.transactions)) {
-        const full = await dataAccess.getBudget(id);
-        if (full) {
-          b = full;
-          budgetStore.updateBudget(id, full);
-        }
-      }
-      if (b) {
-        const mapped = (b.transactions || []).filter(t => !t.deleted).map(t => mapTxToRow(t, b));
+      const full = await dataAccess.getBudget(id);
+      if (full) {
+        budgetStore.updateBudget(id, full);
+        const mapped = (full.transactions || [])
+          .filter((t) => !t.deleted)
+          .map((t) => mapTxToRow(t, full));
         out.push(...mapped);
       }
     }
@@ -140,9 +136,6 @@ export function useTransactions() {
   async function loadInitial(budgetIdOrIds: string | string[]) {
     loading.value = true;
     try {
-      const user = auth.currentUser;
-      if (!user) return;
-      await familyStore.loadFamily(user.uid);
       const ids = Array.isArray(budgetIdOrIds) ? budgetIdOrIds : [budgetIdOrIds];
       rows.value = await hydrateBudgets(ids);
       registerRows.value = rows.value; // Placeholder: same data until register wired

--- a/q-srfm/src/composables/useTransactions.ts
+++ b/q-srfm/src/composables/useTransactions.ts
@@ -84,6 +84,7 @@ export function useTransactions() {
   const registerRows = ref<LedgerRow[]>([]);
   const loading = ref(false);
   const loadingRegister = ref(false);
+  const importedLoaded = ref(false);
 
   const filters = ref<LedgerFilters>({
     search: '',
@@ -127,6 +128,7 @@ export function useTransactions() {
 
   function mapImportedToRow(tx: ImportedTransaction): LedgerRow {
     const accountName =
+      tx.accountName ||
       familyStore.family?.accounts?.find((a) => a.id === tx.accountId)?.name || '';
     return {
       id: tx.id,
@@ -176,6 +178,7 @@ export function useTransactions() {
   }
 
   async function loadImportedTransactions() {
+    if (importedLoaded.value) return;
     loadingRegister.value = true;
     try {
       const imported = await dataAccess.getImportedTransactions();
@@ -183,6 +186,7 @@ export function useTransactions() {
         .filter((t) => !t.deleted)
         .map((t) => mapImportedToRow(t))
         .sort((a, b) => b.date.localeCompare(a.date));
+      importedLoaded.value = true;
     } finally {
       loadingRegister.value = false;
     }
@@ -269,7 +273,6 @@ export function useTransactions() {
       if (!user) return;
       await familyStore.loadFamily(user.uid);
       await budgetStore.loadBudgets(user.uid, familyStore.selectedEntityId);
-      await loadImportedTransactions();
     } catch {
       /* ignore */
     }

--- a/q-srfm/src/composables/useTransactions.ts
+++ b/q-srfm/src/composables/useTransactions.ts
@@ -140,12 +140,15 @@ export function useTransactions() {
       return false;
     });
     const accountName = tx.accountName || account?.name || '';
+    const entityName = tx.accountNumber
+      ? `${accountName} (${tx.accountNumber})`
+      : accountName;
     return {
       id: tx.id,
       date: tx.postedDate,
       payee: tx.payee,
       category: '',
-      entityName: accountName,
+      entityName,
       budgetId: '',
       amount: (tx.creditAmount ?? 0) - (tx.debitAmount ?? 0),
       status: tx.status,

--- a/q-srfm/src/composables/useTransactions.ts
+++ b/q-srfm/src/composables/useTransactions.ts
@@ -37,10 +37,19 @@ export function isDuplicate(tx: BudgetTransaction, list: BudgetTransaction[]): b
   return list.some(
     (other) =>
       other.id !== tx.id &&
-      other.merchant === tx.merchant &&
       other.amount === tx.amount &&
+      merchantSimilar(other.merchant, tx.merchant) &&
       withinDateWindow(tx.date, other.date, 3),
   );
+}
+
+function merchantSimilar(a?: string | null, b?: string | null): boolean {
+  const normalize = (s?: string | null) =>
+    (s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+  const na = normalize(a);
+  const nb = normalize(b);
+  if (!na || !nb) return true;
+  return na.includes(nb) || nb.includes(na);
 }
 
 export function link(tx: BudgetTransaction, linkId: string): void {

--- a/q-srfm/src/dataAccess.ts
+++ b/q-srfm/src/dataAccess.ts
@@ -20,7 +20,7 @@ import { Timestamp } from 'firebase/firestore';
 type RawAccount = Account & { createdAt?: unknown; updatedAt?: unknown };
 
 export class DataAccess {
-  private apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api';
+  private apiBaseUrl = ((import.meta as any)?.env || {}).VITE_API_BASE_URL || 'http://localhost:8080/api';
   // Lazily access the auth store to ensure Pinia is active
   private get authStore() {
     return useAuthStore();

--- a/q-srfm/src/dataAccess.ts
+++ b/q-srfm/src/dataAccess.ts
@@ -20,7 +20,10 @@ import { Timestamp } from 'firebase/firestore';
 type RawAccount = Account & { createdAt?: unknown; updatedAt?: unknown };
 
 export class DataAccess {
-  private apiBaseUrl = ((import.meta as any)?.env || {}).VITE_API_BASE_URL || 'http://localhost:8080/api';
+  private apiBaseUrl = (
+    ((import.meta as unknown) as { env?: Record<string, string> }).env?.VITE_API_BASE_URL ||
+    'http://localhost:8080/api'
+  );
   // Lazily access the auth store to ensure Pinia is active
   private get authStore() {
     return useAuthStore();

--- a/q-srfm/src/firebase/init.ts
+++ b/q-srfm/src/firebase/init.ts
@@ -2,7 +2,7 @@ import { initializeApp } from 'firebase/app';
 import { getAuth, GoogleAuthProvider, onAuthStateChanged, signInWithPopup } from 'firebase/auth';
 import type { User } from 'firebase/auth';
 
-const env = (import.meta as any)?.env || {};
+const env = ((import.meta as unknown) as { env?: Record<string, string> }).env || {};
 const firebaseConfig = {
   apiKey: env.VITE_FIREBASE_API_KEY ?? '',
   authDomain: env.VITE_FIREBASE_AUTH_DOMAIN ?? '',
@@ -18,9 +18,7 @@ if (env.VITE_FIREBASE_API_KEY) {
   provider = new GoogleAuthProvider();
 } else {
   // Test environment stub
-  // @ts-ignore
-  auth = {};
-  // @ts-ignore
+  auth = {} as unknown as ReturnType<typeof getAuth>;
   provider = new GoogleAuthProvider();
 }
 

--- a/q-srfm/src/firebase/init.ts
+++ b/q-srfm/src/firebase/init.ts
@@ -2,16 +2,27 @@ import { initializeApp } from 'firebase/app';
 import { getAuth, GoogleAuthProvider, onAuthStateChanged, signInWithPopup } from 'firebase/auth';
 import type { User } from 'firebase/auth';
 
+const env = (import.meta as any)?.env || {};
 const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY ?? '',
-  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN ?? '',
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID ?? '',
+  apiKey: env.VITE_FIREBASE_API_KEY ?? '',
+  authDomain: env.VITE_FIREBASE_AUTH_DOMAIN ?? '',
+  projectId: env.VITE_FIREBASE_PROJECT_ID ?? '',
 };
-const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080/api';
+const apiBaseUrl = env.VITE_API_BASE_URL || 'http://localhost:8080/api';
 
-const firebaseApp = initializeApp(firebaseConfig);
-const auth = getAuth(firebaseApp);
-const provider = new GoogleAuthProvider();
+let auth: ReturnType<typeof getAuth>;
+let provider: GoogleAuthProvider;
+if (env.VITE_FIREBASE_API_KEY) {
+  const firebaseApp = initializeApp(firebaseConfig);
+  auth = getAuth(firebaseApp);
+  provider = new GoogleAuthProvider();
+} else {
+  // Test environment stub
+  // @ts-ignore
+  auth = {};
+  // @ts-ignore
+  provider = new GoogleAuthProvider();
+}
 
 const signInWithGoogle = async (): Promise<User | null> => {
   const result = await signInWithPopup(auth, provider);

--- a/q-srfm/src/pages/TransactionsPage.vue
+++ b/q-srfm/src/pages/TransactionsPage.vue
@@ -17,8 +17,8 @@ Key props/usage:
       <div class="row items-center q-gutter-md">
         <div class="col-auto text-h5">Transactions</div>
         <q-tabs v-model="tab" dense class="col">
-          <q-tab name="budget" label="Budget Transactions" />
-          <q-tab name="register" label="Register" />
+          <q-tab name="budget" label="Budget Register" />
+          <q-tab name="register" label="Account Register" />
           <q-tab name="match" label="Match Bank Transactions" />
         </q-tabs>
         <q-input
@@ -37,7 +37,7 @@ Key props/usage:
     </div>
 
     <q-tab-panels v-model="tab" animated>
-      <!-- Budget Transactions Tab -->
+      <!-- Budget Register Tab -->
       <q-tab-panel name="budget">
         <div class="filter-bar shadow-2 bg-white q-pa-sm">
           <div class="column q-gutter-sm">
@@ -131,18 +131,25 @@ Key props/usage:
           :columns="budgetColumns"
           :fetch-more="fetchMore"
           :loading="loading"
-          :header-offset="tableHeaderOffset"
         />
       </q-tab-panel>
 
-      <!-- Register Tab -->
+      <!-- Account Register Tab -->
       <q-tab-panel name="register">
         <statement-header class="q-mb-sm" />
         <div class="filter-bar shadow-2 bg-white q-pa-sm">
           <!-- reuse same filters for demo -->
           <div class="row q-col-gutter-sm items-center">
             <q-input v-model="filters.search" dense outlined placeholder="Search" class="col" />
-              <q-checkbox v-model="filters.cleared" label="Cleared Only" class="col-auto" />
+            <q-select
+              v-model="filters.accountId"
+              :options="accountOptions"
+              dense
+              outlined
+              placeholder="Account"
+              class="col-3"
+            />
+            <q-checkbox v-model="filters.cleared" label="Cleared Only" class="col-auto" />
           </div>
         </div>
         <ledger-table
@@ -150,7 +157,6 @@ Key props/usage:
           :columns="registerColumns"
           :fetch-more="fetchMoreRegister"
           :loading="loadingRegister"
-          :header-offset="tableHeaderOffset"
         />
       </q-tab-panel>
 
@@ -178,7 +184,6 @@ import { sortBudgetsByMonthDesc } from 'src/utils/budget';
 
 const tab = ref<'budget' | 'register' | 'match'>('budget');
 const globalSearch = ref('');
-const tableHeaderOffset = 112;
 
 const budgetStore = useBudgetStore();
 const familyStore = useFamilyStore();
@@ -187,6 +192,10 @@ const auth = useAuthStore();
 
 const { selectedBudgetIds } = storeToRefs(uiStore);
 const { selectedEntityId } = storeToRefs(familyStore);
+
+const accountOptions = computed(() =>
+  familyStore.family?.accounts?.map((a) => ({ label: a.name, value: a.id })) || [],
+);
 
 const {
   transactions,
@@ -261,6 +270,7 @@ function removeFilter(key: keyof typeof filters.value) {
 const activeChips = computed<Record<string, unknown>>(() => {
   const res: Record<string, unknown> = {};
   Object.entries(filters.value).forEach(([k, v]) => {
+    if (k === 'accountId') return;
     if (v !== null && v !== '' && v !== false) {
       res[k] = typeof v === 'boolean' ? '' : v;
     }
@@ -282,15 +292,3 @@ function onJump(val: string) {
 
 </script>
 
-<style scoped>
-.top-bar {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-.filter-bar {
-  position: sticky;
-  top: 56px;
-  z-index: 5;
-}
-</style>

--- a/q-srfm/src/pages/TransactionsPage.vue
+++ b/q-srfm/src/pages/TransactionsPage.vue
@@ -145,6 +145,7 @@ import { useBudgetStore } from 'src/store/budget';
 import { useFamilyStore } from 'src/store/family';
 import { useUIStore } from 'src/store/ui';
 import { useAuthStore } from 'src/store/auth';
+import { sortBudgetsByMonthDesc } from 'src/utils/budget';
 
 const tab = ref<'budget' | 'register' | 'match'>('budget');
 const globalSearch = ref('');
@@ -164,9 +165,11 @@ const formatLongMonth = (month: string) => {
 };
 
 const budgetOptions = computed(() =>
-  Array.from(budgetStore.budgets.values())
-    .filter((b) => !selectedEntityId.value || b.entityId === selectedEntityId.value)
-    .map((b) => ({ label: formatLongMonth(b.month), value: b.budgetId || '' })),
+  sortBudgetsByMonthDesc(
+    Array.from(budgetStore.budgets.values()).filter(
+      (b) => !selectedEntityId.value || b.entityId === selectedEntityId.value,
+    ),
+  ).map((b) => ({ label: formatLongMonth(b.month), value: b.budgetId || '' })),
 );
 
 function setCurrentBudgetSelection() {
@@ -176,7 +179,7 @@ function setCurrentBudgetSelection() {
     return;
   }
   const currentMonth = new Date().toISOString().slice(0, 7);
-  const sorted = budgetsArr.sort((a, b) => b.month.localeCompare(a.month));
+  const sorted = sortBudgetsByMonthDesc(budgetsArr);
   const current = sorted.find((b) => b.month === currentMonth) || sorted[0];
   selectedBudgetIds.value = current?.budgetId ? [current.budgetId] : [];
 }

--- a/q-srfm/src/pages/TransactionsPage.vue
+++ b/q-srfm/src/pages/TransactionsPage.vue
@@ -12,7 +12,7 @@ Key props/usage:
 -->
 <template>
   <q-page class="bg-grey-2">
-    <!-- Sticky header: title, tabs, global search -->
+    <!-- Sticky header: title and tabs -->
     <div class="top-bar bg-grey-2 q-px-md q-pt-md">
       <div class="row items-center q-gutter-md">
         <div class="col-auto text-h5">Transactions</div>
@@ -21,18 +21,6 @@ Key props/usage:
           <q-tab name="register" label="Account Register" />
           <q-tab name="match" label="Match Bank Transactions" />
         </q-tabs>
-        <q-input
-          v-model="globalSearch"
-          placeholder="Search"
-          dense
-          outlined
-          debounce="300"
-          class="col-3"
-        >
-          <template #append>
-            <q-icon name="search" />
-          </template>
-        </q-input>
       </div>
     </div>
 
@@ -168,7 +156,7 @@ Key props/usage:
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, ref, watch, onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 import LedgerTable from 'src/components/LedgerTable.vue';
 import StatementHeader from 'src/components/StatementHeader.vue';
@@ -182,7 +170,6 @@ import { useAuthStore } from 'src/store/auth';
 import { sortBudgetsByMonthDesc } from 'src/utils/budget';
 
 const tab = ref<'budget' | 'register' | 'match'>('budget');
-const globalSearch = ref('');
 
 const budgetStore = useBudgetStore();
 const familyStore = useFamilyStore();
@@ -205,7 +192,16 @@ const {
   loading,
   loadingRegister,
   scrollToDate,
+  loadImportedTransactions,
 } = useTransactions();
+
+onMounted(loadBudgets);
+
+watch(tab, async (t) => {
+  if (t === 'register' && registerRows.value.length === 0) {
+    await loadImportedTransactions();
+  }
+});
 
 const minAmtInput = ref('');
 const maxAmtInput = ref('');

--- a/q-srfm/src/pages/TransactionsPage.vue
+++ b/q-srfm/src/pages/TransactionsPage.vue
@@ -134,6 +134,9 @@ Key props/usage:
               dense
               outlined
               placeholder="Account"
+              clearable
+              emit-value
+              map-options
               class="col-3"
             />
             <q-checkbox v-model="filters.cleared" label="Cleared Only" class="col-auto" />
@@ -180,7 +183,10 @@ const { selectedBudgetIds } = storeToRefs(uiStore);
 const { selectedEntityId } = storeToRefs(familyStore);
 
 const accountOptions = computed(() =>
-  familyStore.family?.accounts?.map((a) => ({ label: a.name, value: a.id })) || [],
+  familyStore.family?.accounts?.map((a) => ({
+    label: a.accountNumber ? `${a.name} (${a.accountNumber})` : a.name,
+    value: a.id,
+  })) || [],
 );
 
 const {

--- a/q-srfm/src/pages/TransactionsPage.vue
+++ b/q-srfm/src/pages/TransactionsPage.vue
@@ -66,8 +66,8 @@ Key props/usage:
             <div class="row q-col-gutter-sm">
               <q-input v-model="filters.search" dense outlined placeholder="Search" class="col" />
               <q-input v-model="filters.importedMerchant" dense outlined placeholder="Imported Merchant" class="col-2" />
-              <q-input v-model.number="filters.minAmt" type="number" dense outlined placeholder="Amount Min" class="col-2" />
-              <q-input v-model.number="filters.maxAmt" type="number" dense outlined placeholder="Amount Max" class="col-2" />
+              <q-input v-model="minAmtInput" type="number" dense outlined placeholder="Amount Min" class="col-2" />
+              <q-input v-model="maxAmtInput" type="number" dense outlined placeholder="Amount Max" class="col-2" />
               <q-input v-model="filters.start" dense outlined placeholder="Date" mask="####-##-##" class="col-2">
                 <template #append>
                   <q-icon name="event" class="cursor-pointer">
@@ -128,7 +128,6 @@ Key props/usage:
         </div>
         <ledger-table
           :rows="transactions"
-          :columns="budgetColumns"
           :fetch-more="fetchMore"
           :loading="loading"
         />
@@ -154,9 +153,9 @@ Key props/usage:
         </div>
         <ledger-table
           :rows="registerRows"
-          :columns="registerColumns"
           :fetch-more="fetchMoreRegister"
           :loading="loadingRegister"
+          entity-label="Account"
         />
       </q-tab-panel>
 
@@ -206,9 +205,28 @@ const {
   loading,
   loadingRegister,
   scrollToDate,
-  budgetColumns,
-  registerColumns,
 } = useTransactions();
+
+const minAmtInput = ref('');
+const maxAmtInput = ref('');
+watch(minAmtInput, (v) => {
+  filters.value.minAmt = v === '' ? null : Number(v);
+});
+watch(maxAmtInput, (v) => {
+  filters.value.maxAmt = v === '' ? null : Number(v);
+});
+watch(
+  () => filters.value.minAmt,
+  (v) => {
+    if (v == null) minAmtInput.value = '';
+  },
+);
+watch(
+  () => filters.value.maxAmt,
+  (v) => {
+    if (v == null) maxAmtInput.value = '';
+  },
+);
 
 const formatLongMonth = (month: string) => {
   const [year, monthNum] = month.split('-');

--- a/q-srfm/src/pages/TransactionsPage.vue
+++ b/q-srfm/src/pages/TransactionsPage.vue
@@ -108,10 +108,11 @@ Key props/usage:
                 @click="filters.duplicatesOnly = !filters.duplicatesOnly"
               />
               <q-space />
-              <q-btn dense flat label="Jump to Date" @click="jumpMenu = true" />
-              <q-menu v-model="jumpMenu" anchor="bottom right" self="top right">
-                <q-date v-model="jumpDate" mask="YYYY-MM-DD" @update:model-value="onJump" />
-              </q-menu>
+              <q-btn dense flat label="Jump to Date">
+                <q-menu v-model="jumpMenu" anchor="bottom right" self="top right">
+                  <q-date v-model="jumpDate" mask="YYYY-MM-DD" @update:model-value="onJump" />
+                </q-menu>
+              </q-btn>
             </div>
             <!-- Active filter chips -->
             <div class="q-mt-sm">
@@ -130,6 +131,7 @@ Key props/usage:
           :columns="budgetColumns"
           :fetch-more="fetchMore"
           :loading="loading"
+          :header-offset="tableHeaderOffset"
         />
       </q-tab-panel>
 
@@ -148,6 +150,7 @@ Key props/usage:
           :columns="registerColumns"
           :fetch-more="fetchMoreRegister"
           :loading="loadingRegister"
+          :header-offset="tableHeaderOffset"
         />
       </q-tab-panel>
 
@@ -175,6 +178,7 @@ import { sortBudgetsByMonthDesc } from 'src/utils/budget';
 
 const tab = ref<'budget' | 'register' | 'match'>('budget');
 const globalSearch = ref('');
+const tableHeaderOffset = 112;
 
 const budgetStore = useBudgetStore();
 const familyStore = useFamilyStore();

--- a/q-srfm/src/pages/TransactionsPage.vue
+++ b/q-srfm/src/pages/TransactionsPage.vue
@@ -65,21 +65,14 @@ Key props/usage:
             </div>
             <div class="row q-col-gutter-sm">
               <q-input v-model="filters.search" dense outlined placeholder="Search" class="col" />
-              <q-select
-                v-model="filters.status"
-                :options="statusOptions"
-                dense
-                outlined
-                placeholder="Status"
-                class="col-2"
-              />
               <q-input v-model="filters.importedMerchant" dense outlined placeholder="Imported Merchant" class="col-2" />
-              <q-input v-model.number="filters.min" type="number" dense outlined placeholder="Amount Min" class="col-2" />
-              <q-input v-model="filters.date" dense outlined placeholder="Date" mask="####-##-##" class="col-2">
+              <q-input v-model.number="filters.minAmt" type="number" dense outlined placeholder="Amount Min" class="col-2" />
+              <q-input v-model.number="filters.maxAmt" type="number" dense outlined placeholder="Amount Max" class="col-2" />
+              <q-input v-model="filters.start" dense outlined placeholder="Date" mask="####-##-##" class="col-2">
                 <template #append>
                   <q-icon name="event" class="cursor-pointer">
                     <q-popup-proxy transition-show="scale" transition-hide="scale">
-                      <q-date v-model="filters.date" mask="YYYY-MM-DD" />
+                      <q-date v-model="filters.start" mask="YYYY-MM-DD" />
                     </q-popup-proxy>
                   </q-icon>
                 </template>
@@ -95,17 +88,24 @@ Key props/usage:
               />
               <q-btn
                 dense
-                :color="filters.unmatched ? 'primary' : 'grey-5'"
+                :color="filters.uncleared ? 'primary' : 'grey-5'"
                 text-color="white"
-                label="Unmatched"
-                @click="filters.unmatched = !filters.unmatched"
+                label="Uncleared"
+                @click="filters.uncleared = !filters.uncleared"
               />
               <q-btn
                 dense
-                :color="filters.duplicates ? 'primary' : 'grey-5'"
+                :color="filters.reconciled ? 'primary' : 'grey-5'"
+                text-color="white"
+                label="Reconciled"
+                @click="filters.reconciled = !filters.reconciled"
+              />
+              <q-btn
+                dense
+                :color="filters.duplicatesOnly ? 'primary' : 'grey-5'"
                 text-color="white"
                 label="Duplicates"
-                @click="filters.duplicates = !filters.duplicates"
+                @click="filters.duplicatesOnly = !filters.duplicatesOnly"
               />
               <q-space />
               <q-btn dense flat label="Jump to Date" @click="jumpMenu = true" />
@@ -140,7 +140,7 @@ Key props/usage:
           <!-- reuse same filters for demo -->
           <div class="row q-col-gutter-sm items-center">
             <q-input v-model="filters.search" dense outlined placeholder="Search" class="col" />
-            <q-checkbox v-model="filters.clearedOnly" label="Cleared Only" class="col-auto" />
+              <q-checkbox v-model="filters.cleared" label="Cleared Only" class="col-auto" />
           </div>
         </div>
         <ledger-table
@@ -183,6 +183,19 @@ const auth = useAuthStore();
 
 const { selectedBudgetIds } = storeToRefs(uiStore);
 const { selectedEntityId } = storeToRefs(familyStore);
+
+const {
+  transactions,
+  filters,
+  registerRows,
+  fetchMore,
+  fetchMoreRegister,
+  loading,
+  loadingRegister,
+  scrollToDate,
+  budgetColumns,
+  registerColumns,
+} = useTransactions();
 
 const formatLongMonth = (month: string) => {
   const [year, monthNum] = month.split('-');
@@ -233,18 +246,7 @@ function clearSelectedBudgets() {
   selectedBudgetIds.value = [];
 }
 
-// Filters
-const filters = ref({
-  search: '',
-  status: null as null | string,
-  importedMerchant: '',
-  min: null as null | number,
-  date: '' as string,
-  cleared: false,
-  unmatched: false,
-  duplicates: false,
-  clearedOnly: false,
-});
+// Filters come from useTransactions
 
 function removeFilter(key: keyof typeof filters.value) {
   const current = filters.value[key];
@@ -274,23 +276,6 @@ function onJump(val: string) {
   if (val) scrollToDate(val);
 }
 
-// Data via composable
-const {
-  transactions,
-  registerRows,
-  fetchMore,
-  fetchMoreRegister,
-  loading,
-  loadingRegister,
-  scrollToDate,
-  budgetColumns,
-  registerColumns,
-} = useTransactions();
-
-const statusOptions = [
-  { label: 'Cleared', value: 'C' },
-  { label: 'Unmatched', value: 'U' },
-];
 </script>
 
 <style scoped>

--- a/q-srfm/src/pages/TransactionsPage.vue
+++ b/q-srfm/src/pages/TransactionsPage.vue
@@ -40,63 +40,89 @@ Key props/usage:
       <!-- Budget Transactions Tab -->
       <q-tab-panel name="budget">
         <div class="filter-bar shadow-2 bg-white q-pa-sm">
-          <div class="row q-col-gutter-sm items-center">
+          <div class="column q-gutter-sm">
             <EntitySelector @change="loadBudgets" class="col-auto" />
-            <q-select
-              v-model="selectedBudgetIds"
-              :options="budgetOptions"
-              dense
-              outlined
-              multiple
-              use-chips
-              emit-value
-              map-options
-              placeholder="Select Budgets"
-              class="col-3"
-            />
-            <q-btn
-              dense
-              flat
-              label="Clear All"
-              class="col-auto"
-              @click="clearSelectedBudgets"
-            />
-            <q-input v-model="filters.search" dense outlined placeholder="Search" class="col" />
-            <q-select
-              v-model="filters.status"
-              :options="statusOptions"
-              dense
-              outlined
-              placeholder="Status"
-              class="col-2"
-            />
-            <q-input v-model.number="filters.min" type="number" dense outlined placeholder="Min" class="col-1" />
-            <q-input v-model.number="filters.max" type="number" dense outlined placeholder="Max" class="col-1" />
-            <q-input v-model="filters.date" dense outlined placeholder="Date" mask="####-##-##" class="col-2">
-              <template #append>
-                <q-icon name="event" class="cursor-pointer">
-                  <q-popup-proxy transition-show="scale" transition-hide="scale">
-                    <q-date v-model="filters.date" mask="YYYY-MM-DD" />
-                  </q-popup-proxy>
-                </q-icon>
-              </template>
-            </q-input>
-            <div class="col-auto">
-              <q-btn dense outline icon="event" @click="jumpMenu = true" aria-label="Jump to date" />
+            <div class="row q-col-gutter-sm items-center">
+              <q-select
+                v-model="selectedBudgetIds"
+                :options="budgetOptions"
+                dense
+                outlined
+                multiple
+                use-chips
+                emit-value
+                map-options
+                placeholder="Select Budgets"
+                class="col-6"
+              />
+              <q-btn
+                dense
+                flat
+                label="Clear All"
+                class="col-auto"
+                @click="clearSelectedBudgets"
+              />
+            </div>
+            <div class="row q-col-gutter-sm">
+              <q-input v-model="filters.search" dense outlined placeholder="Search" class="col" />
+              <q-select
+                v-model="filters.status"
+                :options="statusOptions"
+                dense
+                outlined
+                placeholder="Status"
+                class="col-2"
+              />
+              <q-input v-model="filters.importedMerchant" dense outlined placeholder="Imported Merchant" class="col-2" />
+              <q-input v-model.number="filters.min" type="number" dense outlined placeholder="Amount Min" class="col-2" />
+              <q-input v-model="filters.date" dense outlined placeholder="Date" mask="####-##-##" class="col-2">
+                <template #append>
+                  <q-icon name="event" class="cursor-pointer">
+                    <q-popup-proxy transition-show="scale" transition-hide="scale">
+                      <q-date v-model="filters.date" mask="YYYY-MM-DD" />
+                    </q-popup-proxy>
+                  </q-icon>
+                </template>
+              </q-input>
+            </div>
+            <div class="row items-center q-gutter-sm">
+              <q-btn
+                dense
+                :color="filters.cleared ? 'primary' : 'grey-5'"
+                text-color="white"
+                label="Cleared"
+                @click="filters.cleared = !filters.cleared"
+              />
+              <q-btn
+                dense
+                :color="filters.unmatched ? 'primary' : 'grey-5'"
+                text-color="white"
+                label="Unmatched"
+                @click="filters.unmatched = !filters.unmatched"
+              />
+              <q-btn
+                dense
+                :color="filters.duplicates ? 'primary' : 'grey-5'"
+                text-color="white"
+                label="Duplicates"
+                @click="filters.duplicates = !filters.duplicates"
+              />
+              <q-space />
+              <q-btn dense flat label="Jump to Date" @click="jumpMenu = true" />
               <q-menu v-model="jumpMenu" anchor="bottom right" self="top right">
                 <q-date v-model="jumpDate" mask="YYYY-MM-DD" @update:model-value="onJump" />
               </q-menu>
             </div>
-          </div>
-          <!-- Active filter chips -->
-          <div class="q-mt-sm">
-            <q-chip
-              v-for="(val, key) in activeChips"
-              :key="key"
-              dense
-              removable
-              @remove="() => removeChip(key)"
-            >{{ key }}: {{ val }}</q-chip>
+            <!-- Active filter chips -->
+            <div class="q-mt-sm">
+              <q-chip
+                v-for="(val, key) in activeChips"
+                :key="key"
+                dense
+                removable
+                @remove="() => removeChip(key)"
+              >{{ key }}<template v-if="val">: {{ val }}</template></q-chip>
+            </div>
           </div>
         </div>
         <ledger-table
@@ -211,9 +237,12 @@ function clearSelectedBudgets() {
 const filters = ref({
   search: '',
   status: null as null | string,
+  importedMerchant: '',
   min: null as null | number,
-  max: null as null | number,
   date: '' as string,
+  cleared: false,
+  unmatched: false,
+  duplicates: false,
   clearedOnly: false,
 });
 
@@ -226,7 +255,9 @@ function removeFilter(key: keyof typeof filters.value) {
 const activeChips = computed<Record<string, unknown>>(() => {
   const res: Record<string, unknown> = {};
   Object.entries(filters.value).forEach(([k, v]) => {
-    if (v !== null && v !== '' && v !== false) res[k] = v;
+    if (v !== null && v !== '' && v !== false) {
+      res[k] = typeof v === 'boolean' ? '' : v;
+    }
   });
   return res;
 });

--- a/q-srfm/src/store/auth.ts
+++ b/q-srfm/src/store/auth.ts
@@ -2,7 +2,7 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { auth, signInWithGoogle } from '../firebase/init';
-import { signInWithCustomToken } from 'firebase/auth';
+import { onAuthStateChanged, signInWithCustomToken, signOut } from 'firebase/auth';
 import type { User } from 'firebase/auth';
 
 export const useAuthStore = defineStore('auth', () => {
@@ -13,7 +13,8 @@ export const useAuthStore = defineStore('auth', () => {
   function initializeAuth(): Promise<User | null> {
     return new Promise<User | null>((resolve, reject) => {
       console.log('Initializing Firebase auth');
-      const unsubscribe = auth.onAuthStateChanged(
+      const unsubscribe = onAuthStateChanged(
+        auth,
         (firebaseUser) => {
           console.log('Firebase auth state changed:', firebaseUser ? firebaseUser.uid : null);
           user.value = firebaseUser;
@@ -64,7 +65,7 @@ export const useAuthStore = defineStore('auth', () => {
 
   async function logout() {
     try {
-      await auth.signOut();
+      await signOut(auth);
       user.value = null;
       authError.value = null;
     } catch (error) {

--- a/q-srfm/src/store/family.ts
+++ b/q-srfm/src/store/family.ts
@@ -12,13 +12,15 @@ export const useFamilyStore = defineStore("family", () => {
 
   async function loadFamily(userId: string = "") {
     try {
+      if (family.value) return family.value;
       if (!userId) userId = auth.user ? auth.user.uid : "";
       const f = await dataAccess.getUserFamily(userId);
       if (f) {
         family.value = f;
         // Set default entity (e.g., first "Family" type entity)
         if (f.entities?.length) {
-          const defaultEntity = f.entities.find((e: Entity) => e.type === EntityType.Family) || f.entities[0];
+          const defaultEntity =
+            f.entities.find((e: Entity) => e.type === EntityType.Family) || f.entities[0];
           selectedEntityId.value = defaultEntity ? defaultEntity.id : "";
         }
         return f;

--- a/q-srfm/src/types.ts
+++ b/q-srfm/src/types.ts
@@ -72,6 +72,7 @@ export interface Transaction {
 export interface ImportedTransaction {
   id: string;
   accountId: string;
+  accountName?: string;
   accountNumber?: string;
   accountSource?: string;
   payee: string;

--- a/q-srfm/src/utils/budget.ts
+++ b/q-srfm/src/utils/budget.ts
@@ -156,3 +156,7 @@ export async function createBudgetForMonth(
   return defaultBudget;
 }
 
+export function sortBudgetsByMonthDesc(budgets: Budget[]): Budget[] {
+  return budgets.slice().sort((a, b) => b.month.localeCompare(a.month));
+}
+

--- a/q-srfm/tests/transactions.test.ts
+++ b/q-srfm/tests/transactions.test.ts
@@ -10,17 +10,22 @@ test('withinDateWindow', () => {
 });
 
 test('isDuplicate', () => {
-  const t1: BudgetTransaction = {
+  const base: BudgetTransaction = {
     id: '1',
     date: '2024-01-01',
-    payee: 'A',
-    categoryId: 'c1',
-    entityId: 'e1',
-    budgetId: 'b1',
+    merchant: 'A',
+    categories: [],
     amount: -10,
+    notes: '',
+    recurring: false,
+    recurringInterval: 'Monthly',
+    userId: 'u',
+    isIncome: false,
+    taxMetadata: [],
     status: 'U',
   };
-  const t2: BudgetTransaction = { ...t1, id: '2' };
+  const t1: BudgetTransaction = base;
+  const t2: BudgetTransaction = { ...base, id: '2' };
   assert.equal(isDuplicate(t1, [t1, t2]), true);
 });
 
@@ -28,11 +33,15 @@ test('link/unlink', () => {
   const t: BudgetTransaction = {
     id: '3',
     date: '2024-01-01',
-    payee: 'B',
-    categoryId: 'c1',
-    entityId: 'e1',
-    budgetId: 'b1',
+    merchant: 'B',
+    categories: [],
     amount: 5,
+    notes: '',
+    recurring: false,
+    recurringInterval: 'Monthly',
+    userId: 'u',
+    isIncome: false,
+    taxMetadata: [],
     status: 'U',
   };
   link(t, 'imp1');

--- a/q-srfm/tests/transactions.test.ts
+++ b/q-srfm/tests/transactions.test.ts
@@ -3,6 +3,9 @@ import { test } from 'node:test';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore explicit .js import for Node after compilation
 import { withinDateWindow, isDuplicate, link, unlink, BudgetTransaction } from '../src/composables/useTransactions.js';
+// @ts-ignore explicit .js import for Node after compilation
+import { sortBudgetsByMonthDesc } from '../src/utils/budget.js';
+import type { Budget } from '../src/types.js';
 
 test('withinDateWindow', () => {
   assert.equal(withinDateWindow('2024-01-01', '2024-01-03', 3), true);
@@ -48,4 +51,14 @@ test('link/unlink', () => {
   assert.equal(t.linkId, 'imp1');
   unlink(t);
   assert.equal(t.linkId, undefined);
+});
+
+test('sortBudgetsByMonthDesc orders by month descending', () => {
+  const budgets: Budget[] = [
+    { budgetId: '1', familyId: 'f', label: '', month: '2024-03', incomeTarget: 0, categories: [], transactions: [], merchants: [] },
+    { budgetId: '2', familyId: 'f', label: '', month: '2024-01', incomeTarget: 0, categories: [], transactions: [], merchants: [] },
+    { budgetId: '3', familyId: 'f', label: '', month: '2023-12', incomeTarget: 0, categories: [], transactions: [], merchants: [] },
+  ];
+  const sorted = sortBudgetsByMonthDesc(budgets);
+  assert.deepEqual(sorted.map((b) => b.month), ['2024-03', '2024-01', '2023-12']);
 });

--- a/q-srfm/tests/transactions.test.ts
+++ b/q-srfm/tests/transactions.test.ts
@@ -16,7 +16,7 @@ test('isDuplicate', () => {
   const base: BudgetTransaction = {
     id: '1',
     date: '2024-01-01',
-    merchant: 'A',
+    merchant: 'Starbucks',
     categories: [],
     amount: -10,
     notes: '',
@@ -28,8 +28,10 @@ test('isDuplicate', () => {
     status: 'U',
   };
   const t1: BudgetTransaction = base;
-  const t2: BudgetTransaction = { ...base, id: '2' };
+  const t2: BudgetTransaction = { ...base, id: '2', merchant: 'Starbucks Store #123' };
+  const t3: BudgetTransaction = { ...base, id: '3', merchant: 'Local Cafe' };
   assert.equal(isDuplicate(t1, [t1, t2]), true);
+  assert.equal(isDuplicate(t1, [t3]), false);
 });
 
 test('link/unlink', () => {

--- a/q-srfm/tsconfig.tests.json
+++ b/q-srfm/tsconfig.tests.json
@@ -9,5 +9,10 @@
     "skipLibCheck": true,
     "outDir": "dist-tests"
   },
-  "include": ["src/env.d.ts", "src/composables/**/*.ts", "tests/**/*.ts"]
+  "include": [
+    "src/env.d.ts",
+    "src/composables/**/*.ts",
+    "src/utils/**/*.ts",
+    "tests/**/*.ts"
+  ]
 }

--- a/q-srfm/tsconfig.tests.json
+++ b/q-srfm/tsconfig.tests.json
@@ -13,6 +13,11 @@
     "src/env.d.ts",
     "src/composables/**/*.ts",
     "src/utils/**/*.ts",
+    "src/store/**/*.ts",
+    "src/types.ts",
     "tests/**/*.ts"
+  ]
+  ,"exclude": [
+    "src/store/index.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- Default budget filter to current month and remember existing selections
- Add Clear All button and budget selection helper
- Sync transaction rows with budget selection and expose utility helpers
- Reuse core Transaction type for budget helpers and duplicate checks

## Testing
- `npm test` *(fails: Cannot find module '/workspace/srfm/q-srfm/dist-tests/src/store/ui')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b37008a4488329aabbf0d8509c6460