### PR TITLE
Fix settings icons not loading

### DIFF
--- a/q-srfm/quasar.config.ts
+++ b/q-srfm/quasar.config.ts
@@ -35,6 +35,7 @@ export default defineConfig((ctx) => {
 
       'roboto-font', // optional, you are not bound to it
       'material-icons', // optional, you are not bound to it
+      'material-icons-outlined'
     ],
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-file#build
@@ -106,7 +107,7 @@ export default defineConfig((ctx) => {
         }
       },
 
-      // iconSet: 'material-icons', // Quasar icon set
+      iconSet: 'material-icons', // Quasar icon set
       // lang: 'en-US', // Quasar language pack
 
       // For special cases outside of where the auto-import strategy can have an impact

--- a/q-srfm/src/pages/SettingsPage.vue
+++ b/q-srfm/src/pages/SettingsPage.vue
@@ -105,14 +105,10 @@
                     <q-chip v-if="entity.templateBudget" color="success" size="small" class="ml-2">Has Template</q-chip>
                   </div>
                   <div class="col col-auto">
-                    <q-btn variant="plain" color="primary" @click="openEditEntityDialog(entity)">
-                        <q-icon name="edit"></q-icon>
-                    </q-btn>
+                    <q-btn variant="plain" color="primary" @click="openEditEntityDialog(entity)" icon="edit" />
                   </div>
                   <div class="col col-auto">
-                    <q-btn variant="plain" @click="confirmDeleteEntity(entity)" color="error">
-                        <q-icon name="delete_outline"></q-icon>
-                    </q-btn>
+                    <q-btn variant="plain" @click="confirmDeleteEntity(entity)" color="error" icon="o_delete" />
                   </div>
                 </div>
               </q-item>
@@ -143,9 +139,8 @@
                       color="error"
                       @click.stop="confirmDeleteTransactionDoc(props.row)"
                       title="Delete Transaction Document"
-                    >
-                        <q-icon name="delete_outline"></q-icon>
-                    </q-btn>
+                      icon="o_delete"
+                    />
                   </template>
                 </q-table>
                 <div class="q-mt-md">
@@ -174,9 +169,7 @@
                     {{ props.row.transactions?.length || 0 }}
                   </template>
                   <template #body-cell-actions="props">
-                    <q-btn density="compact" variant="plain" color="error" @click.stop="confirmDeleteBudget(props.row)" title="Delete Budget">
-                        <q-icon name="delete_outline"></q-icon>
-                    </q-btn>
+                    <q-btn density="compact" variant="plain" color="error" @click.stop="confirmDeleteBudget(props.row)" title="Delete Budget" icon="o_delete" />
                   </template>
                 </q-table>
                 <div class="q-mt-md">


### PR DESCRIPTION
## Summary
- load outlined material icons and set Quasar to use Material Icons
- switch Settings page buttons to explicit icon props

## Testing
- `npm test` *(fails: test failed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b377ec9fb08329800576dc52079ec3