### PR TITLE
feat: lazy load imported transactions

### DIFF
--- a/api/Controllers/BudgetController.cs
+++ b/api/Controllers/BudgetController.cs
@@ -280,12 +280,12 @@ namespace FamilyBudgetApi.Controllers
 
         [HttpGet("imported-transactions/by-account/{accountId}")]
         [AuthorizeFirebase]
-        public async Task<IActionResult> GetImportedTransactionsByAccountId(string accountId)
+        public async Task<IActionResult> GetImportedTransactionsByAccountId(string accountId, [FromQuery] int offset = 0, [FromQuery] int limit = 100)
         {
             try
             {
                 var userId = HttpContext.Items["UserId"]?.ToString() ?? throw new Exception("User ID not found");
-                var transactions = await _budgetService.GetImportedTransactionsByAccountId(accountId);
+                var transactions = await _budgetService.GetImportedTransactionsByAccountId(accountId, offset, limit);
                 return Ok(transactions);
             }
             catch (Exception ex)

--- a/quasar/src/components/TransactionRegistry.vue
+++ b/quasar/src/components/TransactionRegistry.vue
@@ -1,25 +1,6 @@
 <!-- src/components/TransactionRegistry.vue -->
 <template>
   <q-page fluid>
-    <div class="row">
-      <div class="col col-12 col-md-4">
-        <q-select
-          v-model="selectedAccount"
-          :items="accountOptions"
-          label="Select Account"
-          variant="outlined"
-          item-title="title"
-          item-value="value"
-          @update:modelValue="loadTransactions"
-        ></q-select>
-      </div>
-      <div class="col d-flex align-center col-auto" >
-          <q-btn color="primary" variant="plain" @click="refreshData" :loading="loading">
-            <q-icon start name="refresh"></q-icon>
-            Refresh
-          </q-btn>
-      </div>
-    </div>
     <div class="row" v-if="selectedAccount">
       <div class="col col-12 col-md-4">
         <q-select
@@ -86,7 +67,19 @@
       <q-card-section>Filters</q-card-section>
       <q-card-section>
         <div class="row">
-          <div class="col col-6 col-md-6">
+          <div class="col col-12 col-md-4">
+            <q-select
+              v-model="selectedAccount"
+              :items="accountOptions"
+              placeholder="Account"
+              variant="outlined"
+              item-title="title"
+              item-value="value"
+              clearable
+              @update:modelValue="loadTransactions"
+            ></q-select>
+          </div>
+          <div class="col col-12 col-md-4">
             <q-input
               append-inner-icon="search"
               density="compact"
@@ -99,6 +92,12 @@
           </div>
           <div class="col col-auto">
             <q-checkbox v-model="filterMatched" label="Show Only Unmatched" density="compact" @input="applyFilters"></q-checkbox>
+          </div>
+          <div class="col col-auto d-flex align-center">
+            <q-btn color="primary" variant="plain" @click="refreshData" :loading="loading">
+              <q-icon start name="refresh"></q-icon>
+              Refresh
+            </q-btn>
           </div>
         </div>
         <div class="row">
@@ -205,6 +204,8 @@
         fixed-footer
         height="600"
         :item-class="getRowClass"
+        virtual-scroll
+        @virtual-scroll="onTableVirtualScroll"
       >
         <template v-slot:body-cell-amount="{ row }">
           <span :class="row.isIncome ? 'text-success' : 'text-error'">
@@ -535,6 +536,10 @@ const {
 } = storeToRefs(uiStore);
 const budgets = ref<Budget[]>([]);
 const importedTransactions = ref<ImportedTransaction[]>([]);
+const importedOffset = ref(0);
+const pageSize = 100;
+const hasMoreImported = ref(true);
+const loadingMore = ref(false);
 const accounts = ref<Account[]>([]);
 const accountOptions = ref<{ title: string; value: string }[]>([]);
 const statements = ref<Statement[]>([]);
@@ -853,9 +858,6 @@ async function loadData() {
     await budgetStore.loadBudgets(user.uid);
     budgets.value = Array.from(budgetStore.budgets.values());
 
-    // Load imported transactions
-    importedTransactions.value = await dataAccess.getImportedTransactions();
-
     // Load accounts
     const family = await familyStore.getFamily();
     if (!family) {
@@ -864,28 +866,10 @@ async function loadData() {
     }
     accounts.value = await dataAccess.getAccounts(family.id);
 
-    // Extract unique account numbers and names
-    const budgetAccounts = budgets.value
-      .flatMap((budget) => budget.transactions || [])
-      .filter((tx) => !tx.deleted && tx.accountNumber)
-      .map((tx) => tx.accountNumber!);
-
-    const importedAccounts = importedTransactions.value
-      .filter((tx): tx is ImportedTransaction & { accountNumber: string } => !!tx.accountNumber)
-      .map((tx) => tx.accountNumber);
-
-    const uniqueAccountNumbers = [...new Set([...budgetAccounts, ...importedAccounts])].filter(Boolean) as string[];
-
-    // Create account options with name and number
-    accountOptions.value = uniqueAccountNumbers
-      .map((accountNumber) => {
-        const account = accounts.value.find((acc) => acc.accountNumber === accountNumber);
-        return {
-          title: account ? `${account.name} (${accountNumber})` : `Unknown (${accountNumber})`,
-          value: accountNumber,
-        };
-      })
-      .sort((a, b) => a.title.localeCompare(b.title));
+    accountOptions.value = accounts.value
+      .filter((acc) => ["Bank", "CreditCard", "Investment"].includes(acc.type) && acc.accountNumber)
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((acc) => ({ title: acc.name, value: acc.accountNumber! }));
 
     // Default to first account if available
     if (accountOptions.value.length > 0) {
@@ -900,13 +884,45 @@ async function loadData() {
   }
 }
 
+async function loadImportedTransactions(reset = false) {
+  if (!selectedAccount.value || loadingMore.value || !hasMoreImported.value) return;
+  if (reset) {
+    importedOffset.value = 0;
+    importedTransactions.value = [];
+    hasMoreImported.value = true;
+  }
+  loadingMore.value = true;
+  try {
+    const txs = await dataAccess.getImportedTransactionsByAccountId(
+      selectedAccount.value,
+      importedOffset.value,
+      pageSize
+    );
+    importedTransactions.value = [...importedTransactions.value, ...txs];
+    importedOffset.value += txs.length;
+    if (txs.length < pageSize) {
+      hasMoreImported.value = false;
+    }
+  } catch (error: any) {
+    console.error("Error loading imported transactions:", error);
+    showSnackbar(`Error loading imported transactions: ${error.message}`, "error");
+  } finally {
+    loadingMore.value = false;
+  }
+}
+
+function onTableVirtualScroll({ to }: { to: number }) {
+  if (to >= displayTransactions.value.length - 20) {
+    loadImportedTransactions();
+  }
+}
+
 async function loadTransactions() {
   if (!selectedAccount.value) return;
 
   loading.value = true;
   try {
-    // Transactions are already loaded in budgets.value and importedTransactions.value
-    // Filtering happens in displayTransactions computed property
+    await loadImportedTransactions(true);
     await statementStore.loadStatements(familyId.value, selectedAccount.value);
     statements.value = statementStore.getStatements(familyId.value, selectedAccount.value);
     if (statements.value.length > 0) {

--- a/quasar/src/dataAccess.ts
+++ b/quasar/src/dataAccess.ts
@@ -437,10 +437,13 @@ export class DataAccess {
     );
   }
 
-  async getImportedTransactionsByAccountId(accountId: string): Promise<ImportedTransaction[]> {
+  async getImportedTransactionsByAccountId(accountId: string, offset = 0, limit = 100): Promise<ImportedTransaction[]> {
     console.log(`Fetching imported transactions for accountId: ${accountId}`);
     const headers = await this.getAuthHeaders();
-    const response = await fetch(`${this.apiBaseUrl}/budget/imported-transactions/by-account/${accountId}`, { headers });
+    const response = await fetch(
+      `${this.apiBaseUrl}/budget/imported-transactions/by-account/${accountId}?offset=${offset}&limit=${limit}`,
+      { headers }
+    );
     if (!response.ok) {
       const errorText = await response.text();
       console.error(`Failed to fetch imported transactions: ${response.status} ${response.statusText} - ${errorText}`);


### PR DESCRIPTION
## Summary
- lazily load imported transactions when scrolling transaction registry
- move account filter beside search with alphabetized bank/credit/investment accounts
- add backend pagination for imported transactions

## Testing
- `npx eslint -c eslint.config.js src/components/TransactionRegistry.vue src/dataAccess.ts` *(fails: 13 problems)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b4a4f1f888832982c984352c420180