### PR TITLE
Load full budgets before exporting data

### DIFF
--- a/app/src/views/DataView.vue
+++ b/app/src/views/DataView.vue
@@ -535,8 +535,12 @@ async function loadAllData() {
       selectedEntityId.value = entities[0].id;
     }
 
-    // Load budgets directly from loadAccessibleBudgets
-    budgets.value = await dataAccess.loadAccessibleBudgets(user.uid);
+    // Load full budget details for export
+    const accessibleBudgets = await dataAccess.loadAccessibleBudgets(user.uid);
+    const fullBudgets = await Promise.all(
+      accessibleBudgets.map((b) => dataAccess.getBudget(b.budgetId))
+    );
+    budgets.value = fullBudgets.filter((b): b is Budget => b !== null);
 
     transactions.value = budgets.value.flatMap((budget) => budget.transactions || []);
 

--- a/q-srfm/src/pages/DataPage.vue
+++ b/q-srfm/src/pages/DataPage.vue
@@ -548,8 +548,12 @@ async function loadAllData() {
       selectedEntityId.value = entities[0].id;
     }
 
-    // Load budgets directly from loadAccessibleBudgets
-    budgets.value = await dataAccess.loadAccessibleBudgets(user.uid);
+    // Load full budget details for export
+    const accessibleBudgets = await dataAccess.loadAccessibleBudgets(user.uid);
+    const fullBudgets = await Promise.all(
+      accessibleBudgets.map((b) => dataAccess.getBudget(b.budgetId))
+    );
+    budgets.value = fullBudgets.filter((b): b is Budget => b !== null);
 
     transactions.value = budgets.value.flatMap((budget) => budget.transactions || []);
 

--- a/quasar/src/pages/DataPage.vue
+++ b/quasar/src/pages/DataPage.vue
@@ -532,8 +532,12 @@ async function loadAllData() {
       selectedEntityId.value = entities[0].id;
     }
 
-    // Load budgets directly from loadAccessibleBudgets
-    budgets.value = await dataAccess.loadAccessibleBudgets(user.uid);
+    // Load full budget details for export
+    const accessibleBudgets = await dataAccess.loadAccessibleBudgets(user.uid);
+    const fullBudgets = await Promise.all(
+      accessibleBudgets.map((b) => dataAccess.getBudget(b.budgetId))
+    );
+    budgets.value = fullBudgets.filter((b): b is Budget => b !== null);
 
     transactions.value = budgets.value.flatMap((budget) => budget.transactions || []);
 


### PR DESCRIPTION
## Summary
- fetch full budget records before running the Export All data flow so budget and transaction CSVs contain data
- apply full-budget loading across Quasar and legacy app variants

## Testing
- `npm test`
- `npm run lint` (q-srfm)
- `npm run lint` (app) *(fails: Parsing error: ESLint configured to run on files not in TSConfig)*
- `npm run lint` (quasar) *(fails: 146 problems from ESLint)*

------
https://chatgpt.com/codex/tasks/task_b_68b4a63170248329a6a40808af14a313