### PR TITLE
refactor: improve transaction UI styling

### DIFF
--- a/q-srfm/src/components/CategoryTransactions.vue
+++ b/q-srfm/src/components/CategoryTransactions.vue
@@ -1,13 +1,13 @@
 <!-- CategoryTransactions.vue -->
 <template>
-  <q-page fluid class="category-transactions text-black">
+  <q-page fluid class="category-transactions text-black bg-grey-2 q-pa-md">
     <!-- Header -->
-    <div class="row header">
+    <div class="row header items-center">
       <div class="col">
         <h2 class="category-title">{{ category.name }}</h2>
       </div>
-      <div class="col col-auto">
-        <q-fab :class="isMobile ? 'mr-2' : 'mr-2 mt-2'" icon="close" variant="plain" :absolute="true" location="top" @click="$emit('close')" />
+      <div class="col-auto">
+        <q-btn flat dense icon="close" class="q-mt-sm" @click="$emit('close')" />
       </div>
     </div>
 
@@ -41,10 +41,11 @@
     <div class="row flex-grow-1 mt-4 q-pl-none q-pr-none">
       <div class="col transaction-list q-pl-none q-pr-none">
         <h3 class="section-title q-pb-sm">Transactions ({{ categoryTransactions.length }})</h3>
-        <div class="my-2 bg-white rounded-10 q-pt-sm q-pr-md q-pl-md mb-4">
+        <div class="my-2 bg-white rounded-borders q-pa-sm mb-4">
           <q-input v-model="search" label="Search" dense clearable prepend-icon="search"></q-input>
         </div>
-        <q-list dense class="rounded-10">
+        <q-card flat class="bg-white rounded-borders">
+        <q-list dense class="rounded-borders">
           <q-item
             v-for="transaction in categoryTransactions"
             :key="transaction.id"
@@ -81,11 +82,12 @@
             <q-item-label>No transactions for this category.</q-item-label>
           </q-item>
         </q-list>
+        </q-card>
       </div>
     </div>
 
     <!-- Floating Action Button -->
-    <q-fab icon="add" :app="true" color="primary" @click="$emit('add-transaction')" location="bottom right" class="mr-2" :class="isMobile ? 'mb-14' : 'mb-2'" />
+    <q-fab icon="add" :app="true" color="primary" @click="$emit('add-transaction')" location="bottom left" class="ml-2" :class="isMobile ? 'mb-14' : 'mb-2'" />
 
     <!-- Edit Transaction Dialog -->
     <q-dialog v-model="showEditDialog" :width="!isMobile ? '550px' : undefined" :fullscreen="isMobile">

--- a/q-srfm/src/components/ToggleButton.vue
+++ b/q-srfm/src/components/ToggleButton.vue
@@ -84,16 +84,14 @@ watch(
 
 /* Style for the active button */
 .active {
-  background-color: rgb(
-    var(--v-theme-primary)
-  ); /* Vuetify's default blue color */
+  background-color: var(--q-primary);
   color: white;
 }
 
 /* Style for the inactive button */
 .inactive {
   background-color: #e0e0e0; /* Light gray for inactive */
-  color: black;
+  color: #555;
 }
 
 /* Ensure the buttons are seamlessly connected */

--- a/q-srfm/src/components/TransactionDialog.vue
+++ b/q-srfm/src/components/TransactionDialog.vue
@@ -14,8 +14,8 @@
         <q-btn
           flat
           dense
-          color="negative"
-          label="X"
+          icon="close"
+          color="white"
           class="q-ml-auto"
           @click="handleCancel"
         />

--- a/q-srfm/src/components/TransactionForm.vue
+++ b/q-srfm/src/components/TransactionForm.vue
@@ -1,16 +1,16 @@
 <!-- src/components/TransactionForm.vue -->
 <template>
   <div v-if="isInitialized && locTrnsx?.categories">
-      <div class="row q-pa-none" >
+      <div class="row q-pa-none">
         <div class="col col-6">
-          <q-btn variant="flat" type="submit" color="primary" :loading="isLoading" @click="save" label="Save" />
+          <q-btn flat type="submit" color="primary" :loading="isLoading" @click="save" label="Save" />
         </div>
-        <div class="col text-right col-6" >
+        <div class="col text-right col-6">
           <q-btn
             v-if="showCancel"
             @click="emit('cancel')"
-            variant="flat"
-            type="submit"
+            flat
+            type="button"
             color="primary"
             :loading="isLoading"
             label="Cancel"
@@ -18,64 +18,63 @@
         </div>
       </div>
     <q-form ref="form" @submit.prevent="save">
-      <div class="row form-row" >
-        <div class="col form-col-label" >Date</div>
-        <div class="col form-col col-auto" >
+      <div class="row form-row">
+        <div class="col form-col-label">Date</div>
+        <div class="col form-col col-auto">
           <q-input
             v-model="locTrnsx.date"
             type="date"
             :rules="requiredField"
             @input="updateBudgetMonth"
-            variant="plain"
-            density="compact"
+            dense
+            borderless
             class="text-right"
-          ></q-input>
+          />
         </div>
       </div>
-      <div class="row form-row" >
-        <div class="col form-col-label q-pr-xl" >Merchant</div>
-        <div class="col form-col col-auto"  style="min-width: 150px">
+      <div class="row form-row">
+        <div class="col form-col-label q-pr-xl">Merchant</div>
+        <div class="col form-col col-auto" style="min-width: 150px">
           <q-select
             v-model="locTrnsx.merchant"
-            :items="merchantNames"
+            :options="merchantNames"
             :rules="requiredField"
-            density="compact"
-            variant="plain"
+            dense
+            borderless
             menu-icon=""
             class="text-right"
-            align-end
-          ></q-select>
+          />
         </div>
       </div>
-      <div class="row form-row" >
-        <div class="col form-col-label col-auto" >Total</div>
-        <div class="col form-col" >
-          <Currency-Input v-model="locTrnsx.amount" class="text-right" variant="plain"></Currency-Input>
+      <div class="row form-row">
+        <div class="col form-col-label col-auto">Total</div>
+        <div class="col form-col">
+          <Currency-Input v-model="locTrnsx.amount" class="text-right" borderless></Currency-Input>
         </div>
       </div>
 
       <div class="form-row my-6 ms-n3 q-py-md">
         <div v-for="(split, index) in locTrnsx.categories" :key="index">
-          <div class="row no-gutters" >
-            <div class="col form-col-label q-pr-sm col-auto" no-gutters  :class="locTrnsx.categories.length > 1 ? '' : 'q-pb-md'">
-                <q-icon color="negative" @click="removeSplit(index)" name="close"></q-icon>
+          <div class="row no-gutters">
+            <div class="col form-col-label q-pr-sm col-auto" :class="locTrnsx.categories.length > 1 ? '' : 'q-pb-md'">
+              <q-icon color="negative" @click="removeSplit(index)" name="close" />
             </div>
-            <div class="col">
+            <div class="col q-pr-sm">
               <q-select
                 v-model="split.category"
-                :items="remainingCategories"
+                :options="remainingCategories"
                 label="Category"
                 :rules="requiredField"
-                density="compact"
-                variant="plain"
+                dense
+                borderless
                 menu-icon=""
+                class="full-width"
                 required
-              ></q-select>
+              />
             </div>
-            <div class="col form-col" v-if="locTrnsx.categories.length > 1" no-gutters cols="4">
-              <Currency-Input v-model="split.amount" class="text-right" variant="plain"></Currency-Input>
+            <div class="col" v-if="locTrnsx.categories.length > 1">
+              <Currency-Input v-model="split.amount" class="text-right full-width" borderless></Currency-Input>
             </div>
-            <div class="col form-col" v-if="locTrnsx.categories.length > 1" no-gutters cols="auto"> </div>
           </div>
         </div>
         <div v-if="locTrnsx.categories.length > 1 && remainingSplit !== 0">
@@ -85,33 +84,33 @@
           </q-banner>
         </div>
         <div>
-          <q-btn variant="plain" color="primary" @click="addSplit()">Add Split</q-btn>
+          <q-btn flat color="primary" @click="addSplit()">Add Split</q-btn>
         </div>
       </div>
 
       <!-- Moved Type toggle above Notes -->
-      <div class="row form-row" >
-        <div class="col form-col-label col-auto" >Type</div>
-        <div class="col text-right" >
+      <div class="row form-row">
+        <div class="col form-col-label col-auto">Type</div>
+        <div class="col text-right">
           <ToggleButton v-model="locTrnsx.isIncome" active-text="Income" inactive-text="Expense" />
         </div>
       </div>
 
       <div class="v-row form-row">
-        <q-textarea v-model="locTrnsx.notes" label="Notes" variant="plain" @focus="scrollToNoteField"></q-textarea>
+        <q-textarea v-model="locTrnsx.notes" label="Notes" borderless @focus="scrollToNoteField" />
       </div>
 
-      <div class="row rounded-5 bg-light mb-2 justify-center" >
-        <div class="col font-weight-bold col-auto"  justify="center">Budget</div>
-        <div class="col q-pa-none ma-0 text-right" >
+      <div class="row rounded-5 bg-light mb-2 justify-center">
+        <div class="col font-weight-bold col-auto" justify="center">Budget</div>
+        <div class="col q-pa-none ma-0 text-right">
           <q-select
             v-model="locTrnsx.budgetMonth"
-            :items="availableMonths"
+            :options="availableMonths"
             :rules="requiredField"
-            variant="plain"
-            density="compact"
+            dense
+            borderless
             :disabled="availableMonths.length === 0"
-          ></q-select>
+          />
         </div>
       </div>
 
@@ -122,7 +121,7 @@
       </div>
 
       <q-checkbox v-model="locTrnsx.recurring" label="Recurring"></q-checkbox>
-      <q-select v-if="locTrnsx.recurring" v-model="locTrnsx.recurringInterval" :items="intervals" label="Recurring Interval"></q-select>
+      <q-select v-if="locTrnsx.recurring" v-model="locTrnsx.recurringInterval" :options="intervals" label="Recurring Interval" dense borderless />
 
       <!-- Imported Transaction Fields (Shown only if matched) -->
       <div
@@ -132,37 +131,37 @@
         <div class="row form-row" >
           <div class="col form-col-label" >Posted Date</div>
           <div class="col form-col" >
-            <q-input v-model="locTrnsx.postedDate" type="date" variant="plain" density="compact" readonly></q-input>
+          <q-input v-model="locTrnsx.postedDate" type="date" dense borderless readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >
           <div class="col form-col-label q-pr-xl" >Imported Merchant</div>
           <div class="col form-col"  style="min-width: 150px">
-            <q-input v-model="locTrnsx.importedMerchant" variant="plain" density="compact" readonly></q-input>
+          <q-input v-model="locTrnsx.importedMerchant" dense borderless readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >
           <div class="col form-col-label" >Account Source</div>
           <div class="col form-col" >
-            <q-input v-model="locTrnsx.accountSource" variant="plain" density="compact" readonly></q-input>
+          <q-input v-model="locTrnsx.accountSource" dense borderless readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >
           <div class="col form-col-label" >Account Number</div>
           <div class="col form-col" >
-            <q-input v-model="locTrnsx.accountNumber" variant="plain" density="compact" readonly></q-input>
+          <q-input v-model="locTrnsx.accountNumber" dense borderless readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >
           <div class="col form-col-label" >Check Number</div>
           <div class="col form-col" >
-            <q-input v-model="locTrnsx.checkNumber" variant="plain" density="compact" readonly></q-input>
+          <q-input v-model="locTrnsx.checkNumber" dense borderless readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >
           <div class="col form-col-label" >Status</div>
           <div class="col form-col" >
-            <q-input v-model="locTrnsx.status" variant="plain" density="compact" readonly></q-input>
+          <q-input v-model="locTrnsx.status" dense borderless readonly></q-input>
           </div>
         </div>
         <div class="row form-row" >
@@ -501,6 +500,19 @@ function showSnackbar(text: string, color = "success") {
 <style>
 .mb-2 {
   margin-bottom: 8px;
+}
+
+.form-row {
+  background-color: #f5f5f5;
+  padding: 4px 8px;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.form-col-label {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
 }
 
 .text-right.v-text-field input,


### PR DESCRIPTION
## Summary
- style transaction dialog close button for contrast on blue header
- refine transaction form layout, input styling, and merchant dropdown
- polish category panel spacing and controls

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b4c977c0808329a55ccc1438c7af42