### PR TITLE
Persist register filters with refresh and clear actions

### DIFF
--- a/q-srfm/src/components/MatchBankTransactionsDialog.vue
+++ b/q-srfm/src/components/MatchBankTransactionsDialog.vue
@@ -529,6 +529,23 @@ watch(
   }
 );
 
+watch(
+  () => props.transactions,
+  () => {
+    computeSmartMatchesLocal();
+  },
+  { deep: true }
+);
+
+watch(
+  () => props.remainingImportedTransactions,
+  (newVal) => {
+    remainingImportedTransactions.value = Array.isArray(newVal) ? [...newVal] : [];
+    computeSmartMatchesLocal();
+  },
+  { deep: true }
+);
+
 async function initializeState() {
   remainingImportedTransactions.value = Array.isArray(props.remainingImportedTransactions) ? [...props.remainingImportedTransactions] : [];
   selectedBankTransaction.value = props.selectedBankTransaction || remainingImportedTransactions.value[0] || null;

--- a/q-srfm/src/store/ui.ts
+++ b/q-srfm/src/store/ui.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
+import type { LedgerFilters } from "../composables/useTransactions";
 
 export const useUIStore = defineStore("uiState", () => {
   const selectedAccount = ref<string | null>(null);
@@ -23,6 +24,23 @@ export const useUIStore = defineStore("uiState", () => {
   const entriesIncludeDeleted = ref(false);
   const selectedBudgetIds = ref<string[]>([]);
 
+  const defaultFilters: LedgerFilters = {
+    search: "",
+    importedMerchant: "",
+    cleared: false,
+    uncleared: false,
+    reconciled: false,
+    duplicatesOnly: false,
+    minAmt: null,
+    maxAmt: null,
+    start: null,
+    end: null,
+    accountId: null,
+  };
+
+  const budgetFilters = ref<LedgerFilters>({ ...defaultFilters });
+  const registerFilters = ref<LedgerFilters>({ ...defaultFilters });
+
   return {
     selectedAccount,
     search,
@@ -42,5 +60,7 @@ export const useUIStore = defineStore("uiState", () => {
     entriesFilterDuplicates,
     entriesIncludeDeleted,
     selectedBudgetIds,
+    budgetFilters,
+    registerFilters,
   };
 });


### PR DESCRIPTION
## Summary
- remember budget and account register filters across tab changes
- add Clear All and Refresh buttons to budget and account register tabs
- provide UI store support for persisted ledger filters
- recompute smart matches when data changes to improve batch matching

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b58650d7d08329a853c7bd8e52fe4d