### PR TITLE
fix: set family, entity, and user on import

### DIFF
--- a/q-srfm/src/dataAccess.ts
+++ b/q-srfm/src/dataAccess.ts
@@ -89,6 +89,7 @@ export class DataAccess {
       recurring: Boolean(tx.recurring ?? false),
       recurringInterval: (tx.recurringInterval as Transaction['recurringInterval']) ?? 'Monthly',
       userId: typeof tx.userId === 'string' ? tx.userId : '',
+      familyId: typeof tx.familyId === 'string' ? tx.familyId : undefined,
       isIncome: Boolean(tx.isIncome ?? false),
       accountNumber: typeof tx.accountNumber === 'string' ? tx.accountNumber : undefined,
       accountSource: typeof tx.accountSource === 'string' ? tx.accountSource : undefined,

--- a/q-srfm/src/pages/DataPage.vue
+++ b/q-srfm/src/pages/DataPage.vue
@@ -1413,7 +1413,14 @@ async function confirmImport() {
           const firebaseBudgetId = `${user.uid}_${selectedEntityId.value}_${month}`; // New ID format
           budgetIdMap.set(originalBudgetId, firebaseBudgetId);
           // Create or update the budget
-          const budget = await createBudgetForMonth(month, familyId.value!, user.uid, selectedEntityId.value);
+          const budget = await createBudgetForMonth(
+            month,
+            familyId.value!,
+            user.uid,
+            selectedEntityId.value,
+          );
+          budget.familyId = familyId.value!;
+          budget.entityId = selectedEntityId.value;
           budgetsById.set(firebaseBudgetId, budget);
         }
 
@@ -1469,6 +1476,7 @@ async function confirmImport() {
           const transactionData: Transaction = {
             id: transactionId,
             userId: user.uid,
+            familyId: familyId.value || "",
             budgetMonth: budget.month,
             budgetId: firebaseBudgetId,
             date: txPreview.transactiondate,

--- a/q-srfm/src/types.ts
+++ b/q-srfm/src/types.ts
@@ -54,6 +54,7 @@ export interface Transaction {
     | "Bi-Annually"
     | "Yearly";
   userId: string;
+  familyId?: string;
   isIncome: boolean;
   accountNumber?: string;
   accountSource?: string;


### PR DESCRIPTION
## Summary
- ensure imported budgets receive current family and entity identifiers
- attach family id and user id to transactions created during import
- include family id when mapping transactions from API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b5c5aae78c8329b17d09f5814e4d04