### PR TITLE
fix: ensure budget transactions are loaded

### DIFF
--- a/q-srfm/src/pages/BudgetPage.vue
+++ b/q-srfm/src/pages/BudgetPage.vue
@@ -881,11 +881,20 @@ const updateBudgetForMonth = debounce(async () => {
     const key = defaultBudget.budgetId || budgetId.value;
     const fullBudget = await dataAccess.getBudget(key);
     if (fullBudget) {
-      budget.value = { ...fullBudget, budgetId: key };
-      budgetStore.updateBudget(key, fullBudget);
+      const normalized = {
+        ...fullBudget,
+        budgetId: key,
+        transactions: fullBudget.transactions || [],
+      };
+      budget.value = normalized;
+      budgetStore.updateBudget(key, normalized);
     } else {
       // Fallback to accessible budget if full fetch fails
-      budget.value = { ...defaultBudget, budgetId: key };
+      budget.value = {
+        ...defaultBudget,
+        budgetId: key,
+        transactions: defaultBudget.transactions || [],
+      };
     }
 
     categoryOptions.value = (budget.value.categories || []).map((cat) => cat.name);

--- a/q-srfm/src/pages/BudgetPage.vue
+++ b/q-srfm/src/pages/BudgetPage.vue
@@ -845,6 +845,24 @@ watch(
   },
 );
 
+function deriveCategoriesFromTransactions(transactions: Transaction[] = []): BudgetCategory[] {
+  const map = new Map<string, BudgetCategory>();
+  transactions.forEach((t) => {
+    t.categories.forEach((c) => {
+      if (!map.has(c.category)) {
+        map.set(c.category, {
+          name: c.category,
+          target: 0,
+          isFund: false,
+          group: t.isIncome ? 'Income' : 'Expenses',
+          carryover: 0,
+        });
+      }
+    });
+  });
+  return Array.from(map.values());
+}
+
 const updateBudgetForMonth = debounce(async () => {
   log('updateBudgetForMonth start', {
     selectedEntityId: familyStore.selectedEntityId,
@@ -885,6 +903,10 @@ const updateBudgetForMonth = debounce(async () => {
         ...fullBudget,
         budgetId: key,
         transactions: fullBudget.transactions || [],
+        categories:
+          fullBudget.categories && fullBudget.categories.length > 0
+            ? fullBudget.categories
+            : deriveCategoriesFromTransactions(fullBudget.transactions || []),
       };
       budget.value = normalized;
       budgetStore.updateBudget(key, normalized);
@@ -894,6 +916,10 @@ const updateBudgetForMonth = debounce(async () => {
         ...defaultBudget,
         budgetId: key,
         transactions: defaultBudget.transactions || [],
+        categories:
+          defaultBudget.categories && defaultBudget.categories.length > 0
+            ? defaultBudget.categories
+            : deriveCategoriesFromTransactions(defaultBudget.transactions || []),
       };
     }
 


### PR DESCRIPTION
## Summary
- always preserve transactions when loading a budget so they appear on the budget screen

## Testing
- `npm test --prefix q-srfm`

------
https://chatgpt.com/codex/tasks/task_b_68b5f1209ebc83299791ccd6b83dc19a