### PR TITLE
avoid localStorage quota when budgets grow

### DIFF
--- a/app/src/store/plugins/persistedState.ts
+++ b/app/src/store/plugins/persistedState.ts
@@ -18,6 +18,14 @@ function reviver(_key: string, value: any) {
 }
 
 export default function persistedState({ store }: PiniaPluginContext) {
+  // Persisting the entire budgets store (which contains all transactions) can
+  // easily exceed the browser's localStorage quota.  If we detect the budgets
+  // store, skip persistence altogether to avoid QuotaExceededError when large
+  // imports occur.
+  if (store.$id === 'budgets') {
+    return;
+  }
+
   const storageKey = `pinia-${store.$id}`;
   const fromStorage = localStorage.getItem(storageKey);
   if (fromStorage) {

--- a/q-srfm/src/store/plugins/persistedState.ts
+++ b/q-srfm/src/store/plugins/persistedState.ts
@@ -21,6 +21,14 @@ function reviver(_key: string, value: unknown) {
 }
 
 export default function persistedState({ store }: PiniaPluginContext) {
+  // The budgets store contains all budgets and their transactions. Persisting
+  // this large dataset regularly exceeds the localStorage quota and throws
+  // QuotaExceededError during imports.  Avoid persisting the budgets store to
+  // keep the console clean and the application responsive.
+  if (store.$id === 'budgets') {
+    return;
+  }
+
   const storageKey = `pinia-${store.$id}`;
   const fromStorage = localStorage.getItem(storageKey);
   if (fromStorage) {


### PR DESCRIPTION
## Summary
- skip persisting budgets store to localStorage to prevent QuotaExceededError

## Testing
- `npm test` (app) *(fails: Missing script)*
- `npm run lint` (app) *(fails: parsing errors)*
- `npm test` (q-srfm)
- `npm run lint` (q-srfm)


------
https://chatgpt.com/codex/tasks/task_b_68b60d827a2c8329bf75dbe88e42e037