### PR TITLE
Enable Quasar Dialog plugin for budget deletion

### DIFF
--- a/q-srfm/quasar.config.ts
+++ b/q-srfm/quasar.config.ts
@@ -118,7 +118,8 @@ export default defineConfig((ctx) => {
       // directives: [],
 
       // Quasar plugins
-      plugins: ['Notify', 'Loading']
+      // Include Dialog so components can invoke $q.dialog
+      plugins: ['Notify', 'Loading', 'Dialog']
     },
 
     // animations: 'all', // --- includes all animations


### PR DESCRIPTION
## Summary
- add Quasar Dialog plugin so `$q.dialog` works for delete confirmations

## Testing
- `npm test`
- `npx eslint -c ./eslint.config.js quasar.config.ts`


------
https://chatgpt.com/codex/tasks/task_b_68c4cf40763083299652e2d44446b4d8