### PR TITLE
Add budget merge support to Quasar frontend

### DIFF
--- a/api/Controllers/BudgetController.cs
+++ b/api/Controllers/BudgetController.cs
@@ -146,6 +146,30 @@ namespace FamilyBudgetApi.Controllers
             }
         }
 
+        [HttpPost("merge")]
+        [AuthorizeFirebase]
+        public async Task<IActionResult> MergeBudgets([FromBody] MergeBudgetsRequest request)
+        {
+            try
+            {
+                if (request == null)
+                    return BadRequest("Request body is required");
+
+                if (string.IsNullOrWhiteSpace(request.TargetBudgetId) || string.IsNullOrWhiteSpace(request.SourceBudgetId))
+                    return BadRequest("Both targetBudgetId and sourceBudgetId are required");
+
+                var userId = HttpContext.Items["UserId"]?.ToString() ?? throw new Exception("User ID not found");
+                var userEmail = (await FirebaseAuth.DefaultInstance.GetUserAsync(userId)).Email;
+                var mergedBudget = await _budgetService.MergeBudgets(request.TargetBudgetId, request.SourceBudgetId, userId, userEmail);
+                return Ok(mergedBudget);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error in MergeBudgets: {ex.Message}");
+                return BadRequest(ex.Message);
+            }
+        }
+
         [HttpGet("{budgetId}/edit-history")]
         [AuthorizeFirebase]
         public async Task<IActionResult> GetEditHistory(string budgetId)

--- a/api/Models/Budget.cs
+++ b/api/Models/Budget.cs
@@ -180,6 +180,12 @@ namespace FamilyBudgetApi.Models
         public List<ReconcileRequest> Reconciliations { get; set; }
     }
 
+    public class MergeBudgetsRequest
+    {
+        public string TargetBudgetId { get; set; } = string.Empty;
+        public string SourceBudgetId { get; set; } = string.Empty;
+    }
+
     [FirestoreData]
     public class TemplateBudget
     {

--- a/app/src/dataAccess.ts
+++ b/app/src/dataAccess.ts
@@ -92,6 +92,22 @@ export class DataAccess {
     budgetStore.removeBudget(budgetId);
   }
 
+  async mergeBudgets(targetBudgetId: string, sourceBudgetId: string): Promise<Budget> {
+    const headers = await this.getAuthHeaders();
+    const response = await fetch(`${this.apiBaseUrl}/budget/merge`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ targetBudgetId, sourceBudgetId }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to merge budgets: ${response.statusText}${errorText ? ` - ${errorText}` : ""}`);
+    }
+
+    return await response.json();
+  }
+
   async getEditHistory(budgetId: string): Promise<EditEvent[]> {
     const headers = await this.getAuthHeaders();
     const response = await fetch(`${this.apiBaseUrl}/budget/${budgetId}/edit-history`, { headers });

--- a/q-srfm/src/dataAccess.ts
+++ b/q-srfm/src/dataAccess.ts
@@ -218,6 +218,22 @@ export class DataAccess {
     budgetStore.removeBudget(budgetId);
   }
 
+  async mergeBudgets(targetBudgetId: string, sourceBudgetId: string): Promise<Budget> {
+    const headers = await this.getAuthHeaders();
+    const response = await fetch(`${this.apiBaseUrl}/budget/merge`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ targetBudgetId, sourceBudgetId }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Failed to merge budgets: ${response.statusText}${errorText ? ` - ${errorText}` : ''}`);
+    }
+
+    return await response.json();
+  }
+
   async getEditHistory(budgetId: string): Promise<EditEvent[]> {
     const headers = await this.getAuthHeaders();
     const response = await fetch(`${this.apiBaseUrl}/budget/${budgetId}/edit-history`, { headers });


### PR DESCRIPTION
## Summary
- add a merge budgets API helper in the Quasar data access layer
- enhance the Quasar Manage Budgets tab with selectors, validation messaging, and merge actions that mirror the Vue app
- keep merge selections in sync with refreshed data and reuse formatted labels for success feedback

## Testing
- npm --prefix q-srfm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d8ad0ac8708329895f4942b967ced3