### PR TITLE
Replace TransactionForm merchant select with autocomplete input

### DIFF
--- a/q-srfm/src/components/LedgerTable.vue
+++ b/q-srfm/src/components/LedgerTable.vue
@@ -175,7 +175,22 @@ function money(n: number) {
   return (n < 0 ? '-$' : '$') + Math.abs(n).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 function formatDate(iso: string) {
+  if (!iso) return '';
+
+  // Preserve calendar date for YYYY-MM-DD strings by constructing the date in local time
+  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) {
+    const [year, month, day] = iso.split('-').map((part) => Number(part));
+    const localDate = new Date(year, month - 1, day);
+    return localDate.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+    });
+  }
+
   const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+
   return d.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'numeric',

--- a/q-srfm/src/components/TransactionForm.vue
+++ b/q-srfm/src/components/TransactionForm.vue
@@ -19,19 +19,18 @@
       <div class="row form-row">
         <div class="col form-col-label q-pr-xl">Merchant</div>
         <div class="col form-col col-auto" style="min-width: 150px">
-          <q-select
+          <q-input
             v-model="locTrnsx.merchant"
-            :options="merchantNames"
             :rules="requiredField"
-            use-input
-            hide-selected
-            fill-input
-            clearable
             dense
             borderless
-            menu-icon=""
             class="text-right"
+            clearable
+            :input-attr="{ list: merchantOptionsId }"
           />
+          <datalist :id="merchantOptionsId">
+            <option v-for="merchant in merchantNames" :key="merchant" :value="merchant" />
+          </datalist>
         </div>
       </div>
       <div class="row form-row">
@@ -246,6 +245,7 @@ const isMobile = computed(() => $q.screen.lt.md);
 const goalList = ref<Goal[]>([]);
 const goalOptions = computed(() => goalList.value.map((g) => ({ label: g.name, value: g.id })));
 
+const merchantOptionsId = `merchant-options-${Math.random().toString(36).slice(2, 10)}`;
 const merchantNames = computed(() => merchantStore.merchantNames);
 
 const availableMonths = computed(() => {

--- a/q-srfm/src/components/TransactionForm.vue
+++ b/q-srfm/src/components/TransactionForm.vue
@@ -178,7 +178,7 @@ import type { Budget, Transaction, Goal } from '../types';
 import { toCents, toDollars, todayISO, currentMonthISO } from '../utils/helpers';
 import CurrencyInput from './CurrencyInput.vue';
 import ToggleButton from './ToggleButton.vue';
-import { QForm } from 'quasar';
+import { QForm, QTextarea } from 'quasar';
 import { useMerchantStore } from '../store/merchants';
 import { useBudgetStore } from '../store/budget';
 import { useGoals } from '../composables/useGoals';


### PR DESCRIPTION
## Summary
- replace the TransactionForm merchant selector with a q-input that supports autocomplete via an HTML datalist
- continue sourcing merchant suggestions from the merchant store while keeping existing validation rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d92faf6d508329954bf5efa6cc10b1