### PR TITLE
Fix duplicate filter on transactions page

### DIFF
--- a/q-srfm/src/composables/useTransactions.ts
+++ b/q-srfm/src/composables/useTransactions.ts
@@ -181,9 +181,19 @@ export function useTransactions() {
           }
         }
         if (full) {
-          const mapped = (full.transactions || [])
-            .filter((t) => !t.deleted)
-            .map((t) => mapTxToRow(t, full));
+          const transactions = (full.transactions || []).filter((t) => !t.deleted);
+          const budgetTransactions = transactions as BudgetTransaction[];
+          const duplicateIds = new Set<string>();
+          for (const tx of budgetTransactions) {
+            if (isDuplicate(tx, budgetTransactions)) {
+              duplicateIds.add(tx.id);
+            }
+          }
+          const mapped = budgetTransactions.map((t) => {
+            const row = mapTxToRow(t, full);
+            row.isDuplicate = duplicateIds.has(t.id);
+            return row;
+          });
           out.push(...mapped);
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
- compute duplicate indicators when hydrating budget transactions for the ledger
- mark ledger rows as duplicates so the "potential duplicates" filter works

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d99d26bd1483298cd21063e1db6e87